### PR TITLE
Proposal: support custom text rendering

### DIFF
--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -449,7 +449,7 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, Cartesia
                 _ => panic!("Bug: Invalid orientation specification"),
             };
 
-            let actual_style = &actual_style.pos(Pos::new(h_pos, v_pos));
+            let actual_style = actual_style.pos(Pos::new(h_pos, v_pos));
             area.draw_text(&text, &actual_style, (x0 as i32, y0 as i32))?;
         }
 

--- a/src/drawing/area.rs
+++ b/src/drawing/area.rs
@@ -6,7 +6,7 @@ use crate::style::text_anchor::{HPos, Pos, VPos};
 use crate::style::{Color, SizeDesc, TextStyle};
 
 /// The abstraction of a drawing area
-use plotters_backend::{BackendCoord, DrawingBackend, DrawingErrorKind};
+use plotters_backend::{BackendCoord, BackendTextStyle, DrawingBackend, DrawingErrorKind};
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -508,10 +508,10 @@ impl<DB: DrawingBackend> DrawingArea<DB, Shift> {
     }
 
     /// Draw text on the drawing area
-    pub fn draw_text(
+    pub fn draw_text<TStyle: BackendTextStyle>(
         &self,
         text: &str,
-        style: &TextStyle,
+        style: &TStyle,
         pos: BackendCoord,
     ) -> Result<(), DrawingAreaError<DB>> {
         self.backend_ops(|b| b.draw_text(text, style, (pos.0 + self.rect.x0, pos.1 + self.rect.y0)))


### PR DESCRIPTION
Hello. I created this PR as a means to ask you, if you'd be open to generalization of the text drawing API.  What I've changed here allows me to swap `plotters::style::TextStyle` for my own type implementing `plotters_backend::BackendTextStyle` in arguments of `DrawingArea::draw_text`, which means I can provide my own text renderer.  I can use this to supply my own bitmap font renderer since rusttype doesn't support these (yet at least), it could be also used to replace rusttype with pango or some other font drawing library, which might be useful when a project is already using those.

However trying to allow this everywhere would be a much larger change than what I did here, requiring swapping every `TextStyle` for another type variable `_: BackendTextStyle`, which will have some impact on the public API too.

If you think this is something you'd want implemented I'd be happy to spend the time on it. Thanks for your work on plotters!