### PR TITLE
Exclude target_os=wasi from browser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,22 +23,22 @@ version = "^0.3.*"
 optional = true
 default_features = false
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))'.dependencies]
 ttf-parser = { version = "0.8.2", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 pathfinder_geometry = { version = "0.5.1", optional = true }
 font-kit = { version = "0.7.0", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.image]
+[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))'.dependencies.image]
 version = "0.23.4"
 optional = true
 default-features = false
 features = ["jpeg", "png", "bmp"]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.wasm-bindgen]
 version = "0.2.62"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.web-sys]
 version = "0.3.39"
 features = [
          "Document",
@@ -101,7 +101,7 @@ serde_json = "1.0.57"
 serde = "1.0.115"
 serde_derive = "1.0.115"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.12"
 
 [[bench]]

--- a/src/element/image.rs
+++ b/src/element/image.rs
@@ -1,4 +1,7 @@
-#[cfg(all(not(target_arch = "wasm32"), feature = "image"))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    feature = "image"
+))]
 use image::{DynamicImage, GenericImageView};
 
 use super::{Drawable, PointCollection};
@@ -6,7 +9,10 @@ use plotters_backend::{BackendCoord, DrawingBackend, DrawingErrorKind};
 
 use plotters_bitmap::bitmap_pixel::{PixelFormat, RGBPixel};
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "image"))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    feature = "image"
+))]
 use plotters_bitmap::bitmap_pixel::BGRXPixel;
 
 use plotters_bitmap::BitMapBackend;
@@ -164,7 +170,10 @@ impl<'a, Coord, P: PixelFormat> BitMapElement<'a, Coord, P> {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "image"))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    feature = "image"
+))]
 impl<'a, Coord> From<(Coord, DynamicImage)> for BitMapElement<'a, Coord, RGBPixel> {
     fn from((pos, image): (Coord, DynamicImage)) -> Self {
         let (w, h) = image.dimensions();
@@ -178,7 +187,10 @@ impl<'a, Coord> From<(Coord, DynamicImage)> for BitMapElement<'a, Coord, RGBPixe
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "image"))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    feature = "image"
+))]
 impl<'a, Coord> From<(Coord, DynamicImage)> for BitMapElement<'a, Coord, BGRXPixel> {
     fn from((pos, image): (Coord, DynamicImage)) -> Self {
         let (w, h) = image.dimensions();

--- a/src/style/font/mod.rs
+++ b/src/style/font/mod.rs
@@ -6,19 +6,31 @@
 ///
 /// Thus we need different mechanism for the font implementation
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "ttf"))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    feature = "ttf"
+))]
 mod ttf;
-#[cfg(all(not(target_arch = "wasm32"), feature = "ttf"))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    feature = "ttf"
+))]
 use ttf::FontDataInternal;
 
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "ttf")))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    not(feature = "ttf")
+))]
 mod naive;
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "ttf")))]
+#[cfg(all(
+    not(all(target_arch = "wasm32", not(target_os = "wasi"))),
+    not(feature = "ttf")
+))]
 use naive::FontDataInternal;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 mod web;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use web::FontDataInternal;
 
 mod font_desc;

--- a/src/style/size.rs
+++ b/src/style/size.rs
@@ -51,7 +51,6 @@ impl SizeDesc for f32 {
     }
 }
 
-
 impl SizeDesc for f64 {
     fn in_pixels<D: HasDimension>(&self, _parent: &D) -> i32 {
         *self as i32


### PR DESCRIPTION
Closes #219

There are [many new](https://wasmer.io/) [WebAssembly](https://wasmtime.dev/) runtimes intended to be run outside of the browsers. This pull request makes plotters compatible with them.

The main issue is that `wasm-bindgen` doesn't make sense when the target os is specified as `wasi` and there is no JavaScript environment. Wasi already exposes low level APIs that can be used instead.

A nice side-effect of this pull request is that you can now choose to compile with `target=wasm32-wasi` and still run your .wasm file in the browser, but provide a WASI polyfill instead of `wasm-bindgen`.