### PR TITLE
Add `ab_glyph` font backend

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -34,6 +34,9 @@ ttf-parser = { version = "0.15.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 pathfinder_geometry = { version = "0.5.1", optional = true }
 font-kit = { version = "0.11.0", optional = true }
+ab_glyph = { version = "0.2.12", optional = true }
+once_cell = { version = "1.8.0", optional = true }
+
 
 [target.'cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))'.dependencies.image]
 version = "0.24.3"
@@ -96,6 +99,8 @@ ttf = ["font-kit", "ttf-parser", "lazy_static", "pathfinder_geometry"]
 # dlopen fontconfig C library at runtime instead of linking at build time
 # Can be useful for cross compiling, especially considering fontconfig has lots of C dependencies
 fontconfig-dlopen = ["font-kit/source-fontconfig-dlopen"]
+
+ab_glyph_ = ["ab_glyph", "once_cell"]
 
 # Misc
 datetime = ["chrono"]

--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -100,7 +100,7 @@ ttf = ["font-kit", "ttf-parser", "lazy_static", "pathfinder_geometry"]
 # Can be useful for cross compiling, especially considering fontconfig has lots of C dependencies
 fontconfig-dlopen = ["font-kit/source-fontconfig-dlopen"]
 
-ab_glyph_ = ["ab_glyph", "once_cell"]
+ab_glyph = ["dep:ab_glyph", "once_cell"]
 
 # Misc
 datetime = ["chrono"]

--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -74,7 +74,7 @@ all_series = ["area_series", "line_series", "point_series", "surface_series"]
 all_elements = ["errorbar", "candlestick", "boxplot", "histogram"]
 
 # Tier 1 Backends
-bitmap_backend = ["plotters-bitmap", "ttf"]
+bitmap_backend = ["plotters-bitmap"]
 bitmap_encoder = ["plotters-bitmap/image_encoder"]
 bitmap_gif = ["plotters-bitmap/gif_backend"]
 svg_backend = ["plotters-svg"]

--- a/plotters/src/style/font/ab_glyph.rs
+++ b/plotters/src/style/font/ab_glyph.rs
@@ -56,7 +56,7 @@ impl Error for FontError {}
 impl FontData for FontDataInternal {
     // TODO: can we rename this to `Error`?
     type ErrorType = FontError;
-    fn new(family: FontFamily<'_>, style: FontStyle) -> Result<Self, Self::ErrorType> {
+    fn new(family: FontFamily<'_>, _style: FontStyle) -> Result<Self, Self::ErrorType> {
         Ok(Self {
             font_ref: FONTS
                 .read()
@@ -69,7 +69,7 @@ impl FontData for FontDataInternal {
     // TODO: ngl, it makes no sense that this uses the same error type as `new`
     fn estimate_layout(&self, size: f64, text: &str) -> Result<LayoutBox, Self::ErrorType> {
         let pixel_per_em = size / 1.24;
-        let units_per_em = self.font_ref.units_per_em().unwrap();
+        // let units_per_em = self.font_ref.units_per_em().unwrap();
         let font = self.font_ref.as_scaled(size as f32);
 
         let mut x_pixels = 0f32;
@@ -108,14 +108,13 @@ impl FontData for FontDataInternal {
             prev = Some(c);
             let glyph = font.scaled_glyph(c);
             if let Some(q) = font.outline_glyph(glyph) {
-                use ::std::panic::{self, AssertUnwindSafe};
                 let rect = q.px_bounds();
                 let y_shift = ((size as f32) / 2.0 + rect.min.y) as i32;
                 let x_shift = x_shift as i32;
                 let mut buf = vec![];
                 q.draw(|x, y, c| buf.push((x, y, c)));
                 for (x, y, c) in buf {
-                    draw(x as i32 + x_shift, y as i32 + y_shift, c).map_err(|e| {
+                    draw(x as i32 + x_shift, y as i32 + y_shift, c).map_err(|_e| {
                         // Note: If ever `plotters` adds a tracing or logging crate,
                         // this would be a good place to use it.
                         FontError::Unknown

--- a/plotters/src/style/font/ab_glyph.rs
+++ b/plotters/src/style/font/ab_glyph.rs
@@ -22,7 +22,7 @@ pub struct InvalidFont {
 ///
 /// The `bytes` parameter should be the complete contents
 /// of an OpenType font file, like:
-/// ```
+/// ```ignore
 /// include_bytes!("FiraGO-Regular.otf")
 /// ```
 pub fn register_font(name: &str, bytes: &'static [u8]) -> Result<(), InvalidFont> {

--- a/plotters/src/style/font/ab_glyph.rs
+++ b/plotters/src/style/font/ab_glyph.rs
@@ -1,0 +1,116 @@
+use super::{FontData, FontFamily, FontStyle, LayoutBox};
+use ::core::fmt::{self, Display};
+use ::std::error::Error;
+use ::std::collections::HashMap;
+use ::std::sync::RwLock;
+use ::once_cell::sync::Lazy;
+use ::ab_glyph::{FontRef, Font, ScaleFont};
+
+static FONTS: Lazy<RwLock<HashMap<String, FontRef<'static>>>> = Lazy::new(|| RwLock::new(HashMap::new()));
+pub struct InvalidFont {
+    _priv: (),
+}
+
+/// Register a font in the fonts table.
+pub fn register_font(name: &str, bytes: &'static [u8]) -> Result<(), InvalidFont> {
+    let font = FontRef::try_from_slice(bytes).map_err(|_| InvalidFont { _priv: () })?;
+    let mut lock = FONTS.write().unwrap();
+    lock.insert(name.to_string(), font);
+    Ok(())
+}
+
+#[derive(Clone)]
+pub struct FontDataInternal {
+    font_ref: FontRef<'static>
+}
+
+#[derive(Debug, Clone)]
+pub enum FontError {
+    /// No idea what the problem is
+    Unknown,
+    /// No font data available for the requested family and style.
+    FontUnavailable,
+}
+impl Display for FontError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Since it makes literally no difference to how we'd format
+        // this, just delegate to the derived Debug formatter.
+        write!(f, "{:?}", self)
+    }
+}
+impl Error for FontError {}
+
+impl FontData for FontDataInternal {
+    // TODO: can we rename this to `Error`?
+    type ErrorType = FontError;
+    fn new(family: FontFamily<'_>, style: FontStyle) -> Result<Self, Self::ErrorType> {
+        Ok(Self {
+            font_ref: FONTS.read().unwrap().get(family.as_str()).ok_or(FontError::FontUnavailable)?.clone()
+        })
+    }
+    // TODO: ngl, it makes no sense that this uses the same error type as `new`
+    fn estimate_layout(&self, size: f64, text: &str) -> Result<LayoutBox, Self::ErrorType> {
+        let pixel_per_em = size / 1.24;
+        let units_per_em = self.font_ref.units_per_em().unwrap();
+        let font = self.font_ref.as_scaled(size as f32);
+
+        let mut x_pixels = 0f32;
+
+        let mut prev = None;
+        for c in text.chars() {
+            let glyph_id = font.glyph_id(c);
+            let size = font.h_advance(glyph_id);
+            x_pixels += size;
+            if let Some(pc) = prev {
+                x_pixels += font.kern(pc, glyph_id);
+            }
+            prev = Some(glyph_id);
+        }
+
+        Ok(((0, 0), (x_pixels as i32, pixel_per_em as i32)))
+    }
+    fn draw<E, DrawFunc: FnMut(i32, i32, f32) -> Result<(), E>>(
+        &self,
+        pos: (i32, i32),
+        size: f64,
+        text: &str,
+        mut draw: DrawFunc,
+    ) -> Result<Result<(), E>, Self::ErrorType> {
+        let font = self.font_ref.as_scaled(size as f32);
+        let mut draw = |x: u32, y: u32, c| {
+            let (x, y) = (x as i32, y as i32);
+            let (base_x, base_y) = pos;
+            draw(base_x + x, base_y + y, c)
+        };
+        let mut x_shift = 0f32;
+        let mut prev = None;
+        for c in text.chars() {
+            if let Some(pc) = prev {
+                x_shift += font.kern(font.glyph_id(pc), font.glyph_id(c));
+            }
+            prev = Some(c);
+            let glyph = font.scaled_glyph(c);
+            if let Some(q) = font.outline_glyph(glyph) {
+                use ::std::panic::{self, AssertUnwindSafe};
+                let rect = q.px_bounds();
+                // Vertically center the things.
+                let y_shift = (size as f32 - rect.height()) / 2.0;
+                let y_shift = y_shift as u32;
+                let res = panic::catch_unwind(AssertUnwindSafe(|| {
+                    q.draw(|x, y, c| {
+                        if let Err(_) = draw(x + (x_shift as u32), y + y_shift, c) {
+                            panic!("fail")
+                        }
+                    });
+                }));
+                if let Err(_) = res {
+                    return Err(FontError::Unknown)
+                }
+                x_shift += font.h_advance(font.glyph_id(c));
+            } else {
+                x_shift += font.h_advance(font.glyph_id(c));
+            }
+        }
+        Ok(Ok(()))
+    }
+}

--- a/plotters/src/style/font/ab_glyph.rs
+++ b/plotters/src/style/font/ab_glyph.rs
@@ -89,8 +89,7 @@ impl FontData for FontDataInternal {
                 .read()
                 .unwrap()
                 .get(family.as_str())
-                .map(|fam| fam.get_fallback(style))
-                .flatten()
+                .and_then(|fam| fam.get_fallback(style))
                 .ok_or(FontError::FontUnavailable)?
                 .clone(),
         })

--- a/plotters/src/style/font/ab_glyph.rs
+++ b/plotters/src/style/font/ab_glyph.rs
@@ -54,7 +54,7 @@ pub fn register_font(
     let font = FontRef::try_from_slice(bytes).map_err(|_| InvalidFont { _priv: () })?;
     let mut lock = FONTS.write().unwrap();
     lock.entry(name.to_string())
-        .or_insert_with(|| FontMap::new())
+        .or_insert_with(FontMap::new)
         .insert(style, font);
     Ok(())
 }

--- a/plotters/src/style/font/mod.rs
+++ b/plotters/src/style/font/mod.rs
@@ -22,7 +22,7 @@ use ttf::FontDataInternal;
 mod ab_glyph;
 #[cfg(all(
     not(target_arch = "wasm32"), not(target_os = "wasi"),
-    feature = "ab_glyph_"
+    feature = "ab_glyph_", not(feature = "ttf")
 ))]
 use self::ab_glyph::FontDataInternal;
 #[cfg(all(
@@ -31,8 +31,6 @@ use self::ab_glyph::FontDataInternal;
 ))]
 pub use self::ab_glyph::register_font;
 
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "ttf"), not(feature = "ab_glyph_")))]
-mod naive;
 #[cfg(all(
     not(all(target_arch = "wasm32", not(target_os = "wasi"))),
     not(feature = "ttf"), not(feature = "ab_glyph_")

--- a/plotters/src/style/font/mod.rs
+++ b/plotters/src/style/font/mod.rs
@@ -17,14 +17,30 @@ mod ttf;
 ))]
 use ttf::FontDataInternal;
 
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "wasi"),
+          feature = "ab_glyph_"))]
+mod ab_glyph;
+#[cfg(all(
+    not(target_arch = "wasm32"), not(target_os = "wasi"),
+    feature = "ab_glyph_"
+))]
+use self::ab_glyph::FontDataInternal;
+#[cfg(all(
+    not(target_arch = "wasm32"), not(target_os = "wasi"),
+    feature = "ab_glyph_"
+))]
+pub use self::ab_glyph::register_font;
+
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "ttf"), not(feature = "ab_glyph_")))]
+mod naive;
 #[cfg(all(
     not(all(target_arch = "wasm32", not(target_os = "wasi"))),
-    not(feature = "ttf")
+    not(feature = "ttf"), not(feature = "ab_glyph_")
 ))]
 mod naive;
 #[cfg(all(
     not(all(target_arch = "wasm32", not(target_os = "wasi"))),
-    not(feature = "ttf")
+    not(feature = "ttf"), not(feature = "ab_glyph_")
 ))]
 use naive::FontDataInternal;
 

--- a/plotters/src/style/font/mod.rs
+++ b/plotters/src/style/font/mod.rs
@@ -18,27 +18,27 @@ mod ttf;
 use ttf::FontDataInternal;
 
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "wasi"),
-          feature = "ab_glyph_"))]
+          feature = "ab_glyph"))]
 mod ab_glyph;
 #[cfg(all(
     not(target_arch = "wasm32"), not(target_os = "wasi"),
-    feature = "ab_glyph_", not(feature = "ttf")
+    feature = "ab_glyph", not(feature = "ttf")
 ))]
 use self::ab_glyph::FontDataInternal;
 #[cfg(all(
     not(target_arch = "wasm32"), not(target_os = "wasi"),
-    feature = "ab_glyph_"
+    feature = "ab_glyph"
 ))]
 pub use self::ab_glyph::register_font;
 
 #[cfg(all(
     not(all(target_arch = "wasm32", not(target_os = "wasi"))),
-    not(feature = "ttf"), not(feature = "ab_glyph_")
+    not(feature = "ttf"), not(feature = "ab_glyph")
 ))]
 mod naive;
 #[cfg(all(
     not(all(target_arch = "wasm32", not(target_os = "wasi"))),
-    not(feature = "ttf"), not(feature = "ab_glyph_")
+    not(feature = "ttf"), not(feature = "ab_glyph")
 ))]
 use naive::FontDataInternal;
 

--- a/plotters/src/style/mod.rs
+++ b/plotters/src/style/mod.rs
@@ -20,6 +20,9 @@ pub use colors::full_palette;
 pub use font::{
     FontDesc, FontError, FontFamily, FontResult, FontStyle, FontTransform, IntoFont, LayoutBox,
 };
+#[cfg(all(not(target_arch = "wasm32"), feature = "ab_glyph_"))]
+pub use font::register_font;
+
 pub use shape::ShapeStyle;
 pub use size::{AsRelative, RelativeSize, SizeDesc};
 pub use text::text_anchor;

--- a/plotters/src/style/mod.rs
+++ b/plotters/src/style/mod.rs
@@ -20,7 +20,7 @@ pub use colors::full_palette;
 pub use font::{
     FontDesc, FontError, FontFamily, FontResult, FontStyle, FontTransform, IntoFont, LayoutBox,
 };
-#[cfg(all(not(target_arch = "wasm32"), feature = "ab_glyph_"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ab_glyph"))]
 pub use font::register_font;
 
 pub use shape::ShapeStyle;


### PR DESCRIPTION
I've been using `plotters` in a situation where caring about system fonts is unimportant, and having `font-kit` in my dependency tree has been causing me unnecessary problems. This PR introduces a feature gated font rendering backend based on https://github.com/alexheretic/ab-glyph, which doesn't have those problems for me.

I am willing to restructure or completely rewrite this code as necessary to get some form of this feature merged- I can't say I'm certain this is the best API for it.
I can also, and probably should also, add documentation and tests for it. Lemme know what you think is best and I'll do it.