### PR TITLE
Derive Copy for ShapeStyle

### DIFF
--- a/src/style/shape.rs
+++ b/src/style/shape.rs
@@ -2,7 +2,7 @@ use super::color::{Color, RGBAColor};
 use plotters_backend::{BackendColor, BackendStyle};
 
 /// Style for any of shape
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct ShapeStyle {
     pub color: RGBAColor,
     pub filled: bool,


### PR DESCRIPTION
`ShapeStyle` is a small struct, so I think it's reasonable for it to have a `Copy` instance.

This is useful because `.legend()` takes a `Fn` closure, which we can't `move` values into unless they implement `Copy`.