### PR TITLE
Add derive(Clone) to Cartesian3d and DualCoordChartState

### DIFF
--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -132,6 +132,10 @@ mod test {
             .draw()
             .expect("Draw Secondary axes");
 
+        // test that chart states work correctly with dual coord charts
+        let cs = chart.into_chart_state();
+        let mut chart = cs.clone().restore(&drawing_area);
+
         chart
             .draw_series(std::iter::once(Circle::new((5, 5), 5, &RED)))
             .expect("Drawing error");
@@ -172,8 +176,13 @@ mod test {
 
         chart.configure_axes().draw().expect("Drawing axes");
 
+        // test that chart states work correctly with 3d coordinates
+        let cs = chart.into_chart_state();
+        let mut chart = cs.clone().restore(&drawing_area);
+
         chart
             .draw_series(std::iter::once(Circle::new((5, 5, 5), 5, &RED)))
             .expect("Drawing error");
+
     }
 }

--- a/src/chart/dual_coord.rs
+++ b/src/chart/dual_coord.rs
@@ -32,6 +32,7 @@ pub struct DualCoordChartContext<'a, DB: DrawingBackend, CT1: CoordTranslate, CT
 /// The chart state for a dual coord chart, see the detailed description for `ChartState` for more
 /// information about the purpose of a chart state.
 /// Similar to [ChartState](struct.ChartState.html), but used for the dual coordinate charts.
+#[derive(Clone)]
 pub struct DualCoordChartState<CT1: CoordTranslate, CT2: CoordTranslate> {
     primary: ChartState<CT1>,
     secondary: ChartState<CT2>,

--- a/src/coord/ranged3d/cartesian3d.rs
+++ b/src/coord/ranged3d/cartesian3d.rs
@@ -6,6 +6,7 @@ use plotters_backend::BackendCoord;
 use std::ops::Range;
 
 /// A 3D cartesian coordinate system
+#[derive(Clone)]
 pub struct Cartesian3d<X: Ranged, Y: Ranged, Z: Ranged> {
     pub(crate) logic_x: X,
     pub(crate) logic_y: Y,


### PR DESCRIPTION
Currently, attempting to clone a ChartState fails if either a) the ChartState is from a ChartContext that was built with a 3D Cartesian coordinate system, or b) the ChartState is from a ChartContext that was converted into a dual axis chart context. In both cases, adding the `#[derive(Clone)]` annotation to the corresponding class (`Cartesian3d` and `DualCoordChartState` respectively) resolves the issue. Since dual axis chart contexts and 3D cartesian coordinates are already being used in existing tests in `src/chart/context.rs`, I went ahead and added a line to check that chart contexts could be successfully cloned in both cases.

(This bug was discovered while attempting to adapt the `minifb-demo` example to use a 3D Cartesian coordinate system.)