### PR TITLE
Minor gridline density in 2d and 3d

### DIFF
--- a/examples/3d-plot.rs
+++ b/examples/3d-plot.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         pb.into_matrix()
     });
 
-    chart.configure_axes().max_light_lines(4).draw()?;
+    chart.configure_axes().light_grid_style(BLACK.mix(0.15)).max_light_lines(3).draw()?;
 
     chart
         .draw_series(

--- a/examples/3d-plot.rs
+++ b/examples/3d-plot.rs
@@ -18,7 +18,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         pb.into_matrix()
     });
 
-    chart.configure_axes().light_grid_style(BLACK.mix(0.15)).max_light_lines(3).draw()?;
+    chart
+        .configure_axes()
+        .light_grid_style(BLACK.mix(0.15))
+        .max_light_lines(3)
+        .draw()?;
 
     chart
         .draw_series(

--- a/examples/3d-plot.rs
+++ b/examples/3d-plot.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         pb.into_matrix()
     });
 
-    chart.configure_axes().draw()?;
+    chart.configure_axes().max_light_lines(4).draw()?;
 
     chart
         .draw_series(

--- a/examples/3d-plot2.rs
+++ b/examples/3d-plot2.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             p.into_matrix() // build the projection matrix
         });
 
-        chart.configure_axes().max_light_lines(4).draw()?;
+        chart.configure_axes().light_grid_style(BLACK.mix(0.15)).max_light_lines(3).draw()?;
 
         chart.draw_series(
             SurfaceSeries::xoz(

--- a/examples/3d-plot2.rs
+++ b/examples/3d-plot2.rs
@@ -24,7 +24,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             p.into_matrix() // build the projection matrix
         });
 
-        chart.configure_axes().light_grid_style(BLACK.mix(0.15)).max_light_lines(3).draw()?;
+        chart
+            .configure_axes()
+            .light_grid_style(BLACK.mix(0.15))
+            .max_light_lines(3)
+            .draw()?;
 
         chart.draw_series(
             SurfaceSeries::xoz(

--- a/examples/3d-plot2.rs
+++ b/examples/3d-plot2.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             p.into_matrix() // build the projection matrix
         });
 
-        chart.configure_axes().draw()?;
+        chart.configure_axes().max_light_lines(4).draw()?;
 
         chart.draw_series(
             SurfaceSeries::xoz(

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .margin_right(20)
             .caption(format!("y = x^{}", 1 + 2 * idx), ("sans-serif", 40))
             .build_cartesian_2d(-1f32..1f32, -1f32..1f32)?;
-        cc.configure_mesh().x_labels(5).y_labels(3).draw()?;
+        cc.configure_mesh().x_labels(5).y_labels(3).max_light_lines(4).draw()?;
 
         cc.draw_series(LineSeries::new(
             (-1f32..1f32)

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -68,7 +68,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .margin_right(20)
             .caption(format!("y = x^{}", 1 + 2 * idx), ("sans-serif", 40))
             .build_cartesian_2d(-1f32..1f32, -1f32..1f32)?;
-        cc.configure_mesh().x_labels(5).y_labels(3).max_light_lines(4).draw()?;
+        cc.configure_mesh()
+            .x_labels(5)
+            .y_labels(3)
+            .max_light_lines(4)
+            .draw()?;
 
         cc.draw_series(LineSeries::new(
             (-1f32..1f32)

--- a/examples/matshow.rs
+++ b/examples/matshow.rs
@@ -17,6 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .configure_mesh()
         .x_labels(15)
         .y_labels(15)
+        .max_light_lines(4)
         .x_label_offset(35)
         .y_label_offset(25)
         .disable_x_mesh()

--- a/examples/slc-temp.rs
+++ b/examples/slc-temp.rs
@@ -33,6 +33,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .disable_x_mesh()
         .disable_y_mesh()
         .x_labels(30)
+        .max_light_lines(4)
         .y_desc("Average Temp (F)")
         .draw()?;
     chart

--- a/src/chart/axes3d.rs
+++ b/src/chart/axes3d.rs
@@ -45,28 +45,28 @@ where
         self
     }
 
-    /// Set the maximum number of divisions for the fine grind grid
+    /// Set the maximum number of divisions for the minor grid
     /// - `value`: Maximum desired divisions between two consecutive X labels
     pub fn x_max_light_lines(&mut self, value: usize) -> &mut Self {
         self.light_lines_limit[0] = value;
         self
     }
 
-    /// Set the maximum number of divisions for the fine grind grid
+    /// Set the maximum number of divisions for the minor grid
     /// - `value`: Maximum desired divisions between two consecutive Y labels
     pub fn y_max_light_lines(&mut self, value: usize) -> &mut Self {
         self.light_lines_limit[1] = value;
         self
     }
 
-    /// Set the maximum number of divisions for the fine grind grid
+    /// Set the maximum number of divisions for the minor grid
     /// - `value`: Maximum desired divisions between two consecutive Z labels
     pub fn z_max_light_lines(&mut self, value: usize) -> &mut Self {
         self.light_lines_limit[2] = value;
         self
     }
 
-    /// Set the maximum number of divisions for the fine grind grid
+    /// Set the maximum number of divisions for the minor grid
     /// - `value`: Maximum desired divisions between two consecutive labels in X, Y, and Z
     pub fn max_light_lines(&mut self, value: usize) -> &mut Self {
         self.light_lines_limit[0] = value;
@@ -162,9 +162,18 @@ where
             BoldPoints(self.n_labels[2]),
         );
         let kps_light = chart.get_key_points(
-            LightPoints::new(self.n_labels[0] * self.light_lines_limit[0], self.n_labels[0] * self.light_lines_limit[0]),
-            LightPoints::new(self.n_labels[1] * self.light_lines_limit[1], self.n_labels[1] * self.light_lines_limit[1]),
-            LightPoints::new(self.n_labels[2] * self.light_lines_limit[2], self.n_labels[2] * self.light_lines_limit[2])
+            LightPoints::new(
+                self.n_labels[0],
+                self.n_labels[0] * self.light_lines_limit[0],
+            ),
+            LightPoints::new(
+                self.n_labels[1],
+                self.n_labels[1] * self.light_lines_limit[1],
+            ),
+            LightPoints::new(
+                self.n_labels[2],
+                self.n_labels[2] * self.light_lines_limit[2],
+            ),
         );
 
         let panels = chart.draw_axis_panels(

--- a/src/chart/axes3d.rs
+++ b/src/chart/axes3d.rs
@@ -18,6 +18,7 @@ pub struct Axes3dStyle<'a, 'b, X: Ranged, Y: Ranged, Z: Ranged, DB: DrawingBacke
     pub(super) parent_size: (u32, u32),
     pub(super) target: Option<&'b mut ChartContext<'a, DB, Cartesian3d<X, Y, Z>>>,
     pub(super) tick_size: i32,
+    pub(super) light_lines_limit: [usize; 3],
     pub(super) n_labels: [usize; 3],
     pub(super) bold_line_style: ShapeStyle,
     pub(super) light_line_style: ShapeStyle,
@@ -41,6 +42,36 @@ where
     pub fn tick_size<Size: SizeDesc>(&mut self, size: Size) -> &mut Self {
         let actual_size = size.in_pixels(&self.parent_size);
         self.tick_size = actual_size;
+        self
+    }
+
+    /// Set the maximum number of divisions for the fine grind grid
+    /// - `value`: Maximum desired divisions between two consecutive X labels
+    pub fn x_max_light_lines(&mut self, value: usize) -> &mut Self {
+        self.light_lines_limit[0] = value;
+        self
+    }
+
+    /// Set the maximum number of divisions for the fine grind grid
+    /// - `value`: Maximum desired divisions between two consecutive Y labels
+    pub fn y_max_light_lines(&mut self, value: usize) -> &mut Self {
+        self.light_lines_limit[1] = value;
+        self
+    }
+
+    /// Set the maximum number of divisions for the fine grind grid
+    /// - `value`: Maximum desired divisions between two consecutive Z labels
+    pub fn z_max_light_lines(&mut self, value: usize) -> &mut Self {
+        self.light_lines_limit[2] = value;
+        self
+    }
+
+    /// Set the maximum number of divisions for the fine grind grid
+    /// - `value`: Maximum desired divisions between two consecutive labels in X, Y, and Z
+    pub fn max_light_lines(&mut self, value: usize) -> &mut Self {
+        self.light_lines_limit[0] = value;
+        self.light_lines_limit[1] = value;
+        self.light_lines_limit[2] = value;
         self
     }
 
@@ -104,6 +135,7 @@ where
         Self {
             parent_size,
             tick_size,
+            light_lines_limit: [10, 10, 10],
             n_labels: [10, 10, 10],
             bold_line_style: Into::<ShapeStyle>::into(&BLACK.mix(0.2)),
             light_line_style: Into::<ShapeStyle>::into(&TRANSPARENT),
@@ -130,9 +162,9 @@ where
             BoldPoints(self.n_labels[2]),
         );
         let kps_light = chart.get_key_points(
-            LightPoints::new(self.n_labels[0], self.n_labels[0] * 10),
-            LightPoints::new(self.n_labels[1], self.n_labels[1] * 10),
-            LightPoints::new(self.n_labels[2], self.n_labels[2] * 10),
+            LightPoints::new(self.n_labels[0], self.n_labels[0] * self.light_lines_limit[0]),
+            LightPoints::new(self.n_labels[1], self.n_labels[1] * self.light_lines_limit[1]),
+            LightPoints::new(self.n_labels[2], self.n_labels[2] * self.light_lines_limit[2]),
         );
 
         let panels = chart.draw_axis_panels(

--- a/src/chart/axes3d.rs
+++ b/src/chart/axes3d.rs
@@ -162,9 +162,9 @@ where
             BoldPoints(self.n_labels[2]),
         );
         let kps_light = chart.get_key_points(
-            LightPoints::new(self.n_labels[0], self.n_labels[0] * self.light_lines_limit[0]),
-            LightPoints::new(self.n_labels[1], self.n_labels[1] * self.light_lines_limit[1]),
-            LightPoints::new(self.n_labels[2], self.n_labels[2] * self.light_lines_limit[2]),
+            LightPoints::new(self.n_labels[0] * self.light_lines_limit[0], self.n_labels[0] * self.light_lines_limit[0]),
+            LightPoints::new(self.n_labels[1] * self.light_lines_limit[1], self.n_labels[1] * self.light_lines_limit[1]),
+            LightPoints::new(self.n_labels[2] * self.light_lines_limit[2], self.n_labels[2] * self.light_lines_limit[2])
         );
 
         let panels = chart.draw_axis_panels(

--- a/src/chart/mesh.rs
+++ b/src/chart/mesh.rs
@@ -313,21 +313,21 @@ where
         self
     }
 
-    /// Set the maximum number of divisions for the fine grind grid
+    /// Set the maximum number of divisions for the minor grid
     /// - `value`: Maximum desired divisions between two consecutive X labels
     pub fn x_max_light_lines(&mut self, value: usize) -> &mut Self {
         self.x_light_lines_limit = value;
         self
     }
 
-    /// Set the maximum number of divisions for the fine grind grid
+    /// Set the maximum number of divisions for the minor grid
     /// - `value`: Maximum desired divisions between two consecutive Y labels
     pub fn y_max_light_lines(&mut self, value: usize) -> &mut Self {
         self.y_light_lines_limit = value;
         self
     }
 
-    /// Set the maximum number of divisions for the fine grind grid
+    /// Set the maximum number of divisions for the minor grid
     /// - `value`: Maximum desired divisions between two consecutive labels in X and Y
     pub fn max_light_lines(&mut self, value: usize) -> &mut Self {
         self.x_light_lines_limit = value;

--- a/src/chart/mesh.rs
+++ b/src/chart/mesh.rs
@@ -149,6 +149,8 @@ pub struct MeshStyle<'a, 'b, X: Ranged, Y: Ranged, DB: DrawingBackend> {
     pub(super) draw_y_axis: bool,
     pub(super) x_label_offset: i32,
     pub(super) y_label_offset: i32,
+    pub(super) x_light_lines_limit: usize,
+    pub(super) y_light_lines_limit: usize,
     pub(super) n_x_labels: usize,
     pub(super) n_y_labels: usize,
     pub(super) axis_desc_style: Option<TextStyle<'b>>,
@@ -197,6 +199,8 @@ where
             draw_y_mesh: true,
             draw_x_axis: true,
             draw_y_axis: true,
+            x_light_lines_limit: 10,
+            y_light_lines_limit: 10,
             n_x_labels: 10,
             n_y_labels: 10,
             bold_line_style: None,
@@ -308,6 +312,29 @@ where
         self.axis_style = Some(style.into());
         self
     }
+
+    /// Set the maximum number of divisions for the fine grind grid
+    /// - `value`: Maximum desired divisions between two consecutive X labels
+    pub fn x_max_light_lines(&mut self, value: usize) -> &mut Self {
+        self.x_light_lines_limit = value;
+        self
+    }
+
+    /// Set the maximum number of divisions for the fine grind grid
+    /// - `value`: Maximum desired divisions between two consecutive Y labels
+    pub fn y_max_light_lines(&mut self, value: usize) -> &mut Self {
+        self.y_light_lines_limit = value;
+        self
+    }
+
+    /// Set the maximum number of divisions for the fine grind grid
+    /// - `value`: Maximum desired divisions between two consecutive labels in X and Y
+    pub fn max_light_lines(&mut self, value: usize) -> &mut Self {
+        self.x_light_lines_limit = value;
+        self.y_light_lines_limit = value;
+        self
+    }
+
     /// Set how many labels for the X axis at most
     /// - `value`: The maximum desired number of labels in the X axis
     pub fn x_labels(&mut self, value: usize) -> &mut Self {
@@ -441,8 +468,8 @@ where
 
         target.draw_mesh(
             (
-                LightPoints::new(self.n_y_labels, self.n_y_labels * 10),
-                LightPoints::new(self.n_x_labels, self.n_x_labels * 10),
+                LightPoints::new(self.n_y_labels, self.n_y_labels * self.y_light_lines_limit),
+                LightPoints::new(self.n_x_labels, self.n_x_labels * self.x_light_lines_limit),
             ),
             &light_style,
             &x_label_style,


### PR DESCRIPTION
The 2d grid can be seen on the tests at `sample.png`; the 3d grid can be seen on the tests at `3d-plot.svg` and `3d-plot2.gif`.

![sample](https://user-images.githubusercontent.com/127711/172487579-f32e5d80-e6d8-4594-b9a4-051b1434ceda.png)

![3d-plot](https://user-images.githubusercontent.com/127711/172487615-2665ed1c-b739-4a26-95c8-66a840307df0.svg)

![3d-plot2](https://user-images.githubusercontent.com/127711/172487631-727b9ec6-a837-4379-be5d-7961ec2c6016.gif)

Close #303 