### PR TITLE
Shorten some lifetimes to prevent borrowing errors. Close #363

### DIFF
--- a/examples/minifb-demo/Cargo.toml
+++ b/examples/minifb-demo/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-minifb = "0.13.0"
+minifb = "0.23.0"
 plotters = { path = "../.." , default_features = false, features = ["ttf"]}
 plotters-bitmap = {version = "^0.3.*", default_features = false}

--- a/examples/minifb-demo/src/main.rs
+++ b/examples/minifb-demo/src/main.rs
@@ -6,11 +6,11 @@ use std::collections::VecDeque;
 use std::error::Error;
 use std::time::SystemTime;
 use std::borrow::{Borrow, BorrowMut};
-const W: usize = 480;
-const H: usize = 320;
+const W: usize = 800;
+const H: usize = 600;
 
 const SAMPLE_RATE: f64 = 10_000.0;
-const FREAME_RATE: f64 = 30.0;
+const FRAME_RATE: f64 = 30.0;
 
 struct BufferWrapper(Vec<u32>);
 impl Borrow<[u8]> for BufferWrapper {
@@ -119,7 +119,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let phase_y = 2.0 * epoch * std::f64::consts::PI * fy + yphase;
         data.push_back((epoch, phase_x.sin(), phase_y.sin()));
 
-        if epoch - last_flushed > 1.0 / FREAME_RATE {
+        if epoch - last_flushed > 1.0 / FRAME_RATE {
             {
                 let root = BitMapBackend::<BGRXPixel>::with_buffer_and_format(
                     buf.borrow_mut(),
@@ -170,8 +170,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                         }
                         xphase += 2.0 * epoch * std::f64::consts::PI * (old_fx - fx);
                         yphase += 2.0 * epoch * std::f64::consts::PI * (old_fy - fy);
+                        window.set_title(&get_window_title(fx, fy, yphase - xphase));
                     }
-                    window.set_title(&get_window_title(fx, fy, yphase - xphase));
                 }
             }
 

--- a/examples/minifb-demo/src/main.rs
+++ b/examples/minifb-demo/src/main.rs
@@ -147,35 +147,34 @@ fn main() -> Result<(), Box<dyn Error>> {
                 }
                 root.present()?;
 
-                if let Some(keys) = window.get_keys_pressed(KeyRepeat::Yes) {
-                    for key in keys {
-                        let old_fx = fx;
-                        let old_fy = fy;
-                        match key {
-                            Key::Equal => {
-                                fy += 0.1;
-                            }
-                            Key::Minus => {
-                                fy -= 0.1;
-                            }
-                            Key::Key0 => {
-                                fx += 0.1;
-                            }
-                            Key::Key9 => {
-                                fx -= 0.1;
-                            }
-                            _ => {
-                                continue;
-                            }
+                let keys = window.get_keys_pressed(KeyRepeat::Yes);
+                for key in keys {
+                    let old_fx = fx;
+                    let old_fy = fy;
+                    match key {
+                        Key::Equal => {
+                            fy += 0.1;
                         }
-                        xphase += 2.0 * epoch * std::f64::consts::PI * (old_fx - fx);
-                        yphase += 2.0 * epoch * std::f64::consts::PI * (old_fy - fy);
-                        window.set_title(&get_window_title(fx, fy, yphase - xphase));
+                        Key::Minus => {
+                            fy -= 0.1;
+                        }
+                        Key::Key0 => {
+                            fx += 0.1;
+                        }
+                        Key::Key9 => {
+                            fx -= 0.1;
+                        }
+                        _ => {
+                            continue;
+                        }
                     }
+                    xphase += 2.0 * epoch * std::f64::consts::PI * (old_fx - fx);
+                    yphase += 2.0 * epoch * std::f64::consts::PI * (old_fy - fy);
+                    window.set_title(&get_window_title(fx, fy, yphase - xphase));
                 }
             }
 
-            window.update_with_buffer(buf.borrow())?;
+            window.update_with_buffer(buf.borrow(), W, H)?;
             last_flushed = epoch;
         }
 


### PR DESCRIPTION
Shorten some lifetimes to prevent borrowing errors in the `minifb` example.

Close #363