### PR TITLE
Proposal to use git-master dependencies for collaboration, testing, and CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,21 @@ exclude = ["doc-template", "plotters-doc-data"]
 [dependencies]
 num-traits = "0.2.14"
 chrono = { version = "0.4.19", optional = true }
-plotters-svg = {version = "^0.3.*", optional = true}
 
 [dependencies.plotters-backend]
-version = "^0.3"
+git = "https://github.com/plotters-rs/plotters-backend"
+# version = "0.3.1"
 
 [dependencies.plotters-bitmap]
-version = "^0.3"
-optional = true
 default_features = false
+git = "https://github.com/plotters-rs/plotters-bitmap"
+optional = true
+# version = "0.3.1"
+
+[dependencies.plotters-svg]
+git = "https://github.com/plotters-rs/plotters-svg"
+optional = true
+# version = "0.3.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ttf-parser = { version = "0.15.0", optional = true }


### PR DESCRIPTION
This proposal aims to improve collaboration, testing, and CI by altering the version of the `plotters-backend`, `plotters-bitmap`, and `plotters-svg` dependencies in `Cargo.toml`. Instead of using the stable versions of those crates, the git-master versions are used.

Using the `git-master` versions of the `plotters-` crates is vital for pre-release quality assurance and frustration-free collaboration in Plotters. It also reduces surprises at release time.

Note: [crates.io](https://crates.io/) does not allow packages to be published with git dependencies. See [The Cargo Book](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) for more information. `Cargo.toml` should be updated to the stable versions right before a new release.