### PR TITLE
Bump chrono to 0.4.20

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["doc-template", "plotters-doc-data"]
 
 [dependencies]
 num-traits = "0.2.14"
-chrono = { version = "0.4.19", optional = true }
+chrono = { version = "0.4.20", optional = true }
 
 [dependencies.plotters-backend]
 path = "../plotters-backend"


### PR DESCRIPTION
Chrono now - 0.4.20 - has localtime_r RIR that has addressed the past security issue around it :partying_face: 

We've updated here:
https://rustsec.org/advisories/RUSTSEC-2020-0159.html