### PR TITLE
Export the `doc` macro, to use of `define_color`

### DIFF
--- a/plotters/src/style/colors/mod.rs
+++ b/plotters/src/style/colors/mod.rs
@@ -3,6 +3,7 @@ use super::{RGBAColor, RGBColor};
 
 // Macro for allowing dynamic creation of doc attributes.
 // Taken from https://stackoverflow.com/questions/60905060/prevent-line-break-in-doc-test
+#[macro_export]
 macro_rules! doc {
     {
         $(#[$m:meta])*

--- a/plotters/src/style/colors/mod.rs
+++ b/plotters/src/style/colors/mod.rs
@@ -1,8 +1,8 @@
 //! Basic predefined colors.
 use super::{RGBAColor, RGBColor};
 
-// Macro for allowing dynamic creation of doc attributes.
 // Taken from https://stackoverflow.com/questions/60905060/prevent-line-break-in-doc-test
+/// Macro for allowing dynamic creation of doc attributes.
 #[macro_export]
 macro_rules! doc {
     {


### PR DESCRIPTION
This change exports the `doc` macro, which is required to be exported for the already exported `define_color` macro to work.  This has been documented in bug #413 