### PR TITLE
Fix broken link of example in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/target
 .vscode/*
 Cargo.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
 - A new Plotters Developer's Guide is a work in progress. The preview version is available [here](https://plotters-rs.github.io/book).
 - Try Plotters with an interactive Jupyter notebook, or view [here](https://plotters-rs.github.io/plotters-doc-data/evcxr-jupyter-integration.html) for the static HTML version.
 - To view the WASM example, go to this [link](https://plotters-rs.github.io/wasm-demo/www/index.html)
-- Currently we have all the internal code ready for console plotting, but a console based backend is still not ready. See [this example](https://github.com/38/plotters/blob/master/examples/console.rs) for how to plot on console with a customized backend.
+- Currently we have all the internal code ready for console plotting, but a console based backend is still not ready. See [this example](https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs) for how to plot on console with a customized backend.
 - Plotters has moved all backend code to separate repositories, check [FAQ list](#faq-list) for details
 - Some interesting [demo projects](#demo-projects) are available, feel free to try them out.
 
@@ -27,19 +27,19 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
 
 To view the source code for each example, please click on the example image.
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/chart.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/chart.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/sample.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/stock.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/stock.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/stock.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/histogram.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/histogram.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/histogram.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters#quick-start">
+<a href="https://github.com/plotters-rs/plotters#quick-start">
     <img src="https://plotters-rs.github.io/plotters-doc-data/0.png" class="galleryItem" width=200px></img>
 </a>
 
@@ -47,11 +47,11 @@ To view the source code for each example, please click on the example image.
 	<img src="https://plotters-rs.github.io/plotters-doc-data/console-2.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/mandelbrot.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/mandelbrot.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/mandelbrot.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters#trying-with-jupyter-evcxr-kernel-interactively">
+<a href="https://github.com/plotters-rs/plotters#trying-with-jupyter-evcxr-kernel-interactively">
     <img src="https://plotters-rs.github.io/plotters-doc-data/evcxr_animation.gif" class="galleryItem" width=200px></img>
 </a>
 
@@ -60,71 +60,71 @@ To view the source code for each example, please click on the example image.
     <img src="https://plotters-rs.github.io/plotters-doc-data/plotters-piston.gif" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/normal-dist.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/normal-dist.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/normal-dist.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/two-scales.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/two-scales.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/twoscale.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/matshow.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/matshow.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/matshow.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/sierpinski.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/sierpinski.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/sierpinski.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/normal-dist2.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/normal-dist2.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/normal-dist2.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/errorbar.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/errorbar.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/errorbar.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/slc-temp.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/slc-temp.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/slc-temp.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/area-chart.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/area-chart.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/area-chart.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/snowflake.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/snowflake.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/snowflake.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/animation.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/animation.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/animation.gif" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/console.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/console-example.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/console.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/console.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/blit-bitmap.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/blit-bitmap.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/blit-bitmap.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/boxplot.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/boxplot.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/boxplot.svg" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/3d-plot.svg" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot2.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot2.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/3d-plot2.gif" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/tick_control.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/tick_control.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/tick_control.svg" class="galleryItem" width=200px></img>
 </a>
 
@@ -221,7 +221,7 @@ The feature `evcxr` should be enabled when including Plotters to Jupyter Noteboo
 The following code shows a minimal example of this.
 
 ```text
-:dep plotters = { git = "https://github.com/38/plotters", default_features = false, features = ["evcxr"] }
+:dep plotters = { git = "https://github.com/plotters-rs/plotters", default_features = false, features = ["evcxr"] }
 extern crate plotters;
 use plotters::prelude::*;
 
@@ -487,14 +487,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Development Version
 
-Find the latest development version of Plotters on [GitHub](https://github.com/38/plotters.git).
+Find the latest development version of Plotters on [GitHub](https://github.com/plotters-rs/plotters.git).
 Clone the repository and learn more about the Plotters API and ways to contribute. Your help is needed!
 
 If you want to add the development version of Plotters to your project, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-plotters = { git = "https://github.com/38/plotters.git" }
+plotters = { git = "https://github.com/plotters-rs/plotters.git" }
 ```
 
 ### Reducing Depending Libraries && Turning Off Backends
@@ -508,7 +508,7 @@ For example, the following dependency description would avoid compiling with bit
 
 ```toml
 [dependencies]
-plotters = { git = "https://github.com/38/plotters.git", default_features = false, features = ["svg"] }
+plotters = { git = "https://github.com/plotters-rs/plotters.git", default_features = false, features = ["svg"] }
 ```
 
 The library also allows consumers to make use of the [`Palette`](https://crates.io/crates/palette/) crate's color types by default.

--- a/doc-template/readme.template.md
+++ b/doc-template/readme.template.md
@@ -19,7 +19,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
 - A new Plotters Developer's Guide is a work in progress. The preview version is available [here](https://plotters-rs.github.io/book).
 - Try Plotters with an interactive Jupyter notebook, or view [here](https://plotters-rs.github.io/plotters-doc-data/evcxr-jupyter-integration.html) for the static HTML version.
 - To view the WASM example, go to this [link](https://plotters-rs.github.io/wasm-demo/www/index.html)
-- Currently we have all the internal code ready for console plotting, but a console based backend is still not ready. See [this example](https://github.com/38/plotters/blob/master/examples/console.rs) for how to plot on console with a customized backend.
+- Currently we have all the internal code ready for console plotting, but a console based backend is still not ready. See [this example](https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs) for how to plot on console with a customized backend.
 - Plotters has moved all backend code to separate repositories, check [FAQ list](#faq-list) for details
 - Some interesting [demo projects](#demo-projects) are available, feel free to try them out.
 
@@ -69,7 +69,7 @@ The feature `evcxr` should be enabled when including Plotters to Jupyter Noteboo
 The following code shows a minimal example of this.
 
 ```text
-:dep plotters = { git = "https://github.com/38/plotters", default_features = false, features = ["evcxr"] }
+:dep plotters = { git = "https://github.com/plotters-rs/plotters", default_features = false, features = ["evcxr"] }
 extern crate plotters;
 use plotters::prelude::*;
 
@@ -230,14 +230,14 @@ $$../examples/chart.rs$$
 
 ### Development Version
 
-Find the latest development version of Plotters on [GitHub](https://github.com/38/plotters.git).
+Find the latest development version of Plotters on [GitHub](https://github.com/plotters-rs/plotters.git).
 Clone the repository and learn more about the Plotters API and ways to contribute. Your help is needed!
 
 If you want to add the development version of Plotters to your project, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-plotters = { git = "https://github.com/38/plotters.git" }
+plotters = { git = "https://github.com/plotters-rs/plotters.git" }
 ```
 
 ### Reducing Depending Libraries && Turning Off Backends
@@ -251,7 +251,7 @@ For example, the following dependency description would avoid compiling with bit
 
 ```toml
 [dependencies]
-plotters = { git = "https://github.com/38/plotters.git", default_features = false, features = ["svg"] }
+plotters = { git = "https://github.com/plotters-rs/plotters.git", default_features = false, features = ["svg"] }
 ```
 
 The library also allows consumers to make use of the [`Palette`](https://crates.io/crates/palette/) crate's color types by default.

--- a/doc-template/readme/gallery
+++ b/doc-template/readme/gallery
@@ -1,18 +1,18 @@
 To view the source code for each example, please click on the example image.
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/chart.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/chart.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/sample.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/stock.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/stock.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/stock.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/histogram.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/histogram.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/histogram.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters#quick-start">
+<a href="https://github.com/plotters-rs/plotters#quick-start">
     <img src="https://plotters-rs.github.io/plotters-doc-data/0.png" class="galleryItem" width=200px></img>
 </a>
 
@@ -20,11 +20,11 @@ To view the source code for each example, please click on the example image.
 	<img src="https://plotters-rs.github.io/plotters-doc-data/console-2.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/mandelbrot.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/mandelbrot.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/mandelbrot.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters#trying-with-jupyter-evcxr-kernel-interactively">
+<a href="https://github.com/plotters-rs/plotters#trying-with-jupyter-evcxr-kernel-interactively">
     <img src="https://plotters-rs.github.io/plotters-doc-data/evcxr_animation.gif" class="galleryItem" width=200px></img>
 </a>
 
@@ -33,70 +33,70 @@ To view the source code for each example, please click on the example image.
     <img src="https://plotters-rs.github.io/plotters-doc-data/plotters-piston.gif" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/normal-dist.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/normal-dist.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/normal-dist.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/two-scales.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/two-scales.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/twoscale.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/matshow.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/matshow.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/matshow.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/sierpinski.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/sierpinski.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/sierpinski.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/normal-dist2.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/normal-dist2.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/normal-dist2.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/errorbar.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/errorbar.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/errorbar.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/slc-temp.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/slc-temp.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/slc-temp.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/area-chart.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/area-chart.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/area-chart.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/snowflake.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/snowflake.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/snowflake.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/animation.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/animation.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/animation.gif" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/console.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/console-example.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/console.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/console.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/blit-bitmap.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/blit-bitmap.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/blit-bitmap.png" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/boxplot.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/boxplot.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/boxplot.svg" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/3d-plot.svg" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot2.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot2.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/3d-plot2.gif" class="galleryItem" width=200px></img>
 </a>
 
-<a href="https://github.com/38/plotters/blob/master/plotters/examples/tick_control.rs">
+<a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/tick_control.rs">
 	<img src="https://plotters-rs.github.io/plotters-doc-data/tick_control.svg" class="galleryItem" width=200px></img>
 </a>

--- a/doc-template/rustdoc/gallery
+++ b/doc-template/rustdoc/gallery
@@ -4,7 +4,7 @@
     </a>
     <div class="galleryText">
         Multiple Plot
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/chart.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/chart.rs">[code]</a>
     </div>
 </div>
 
@@ -14,7 +14,7 @@
     </a>
     <div class="galleryText">
         Candlestick Plot
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/stock.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/stock.rs">[code]</a>
     </div>
 </div>
 
@@ -24,7 +24,7 @@
     </a>
     <div class="galleryText">
        Histogram
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/histogram.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/histogram.rs">[code]</a>
     </div>
 </div>
 
@@ -52,7 +52,7 @@
     </a>
     <div class="galleryText">
         Mandelbrot set
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/mandelbrot.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/mandelbrot.rs">[code]</a>
     </div>
 </div>
 
@@ -82,7 +82,7 @@
     </a>
     <div class="galleryText">
 		Histogram with Scatter
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/normal-dist.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/normal-dist.rs">[code]</a>
     </div>
 </div>
 
@@ -92,7 +92,7 @@
     </a>
     <div class="galleryText">
 		Dual Y-Axis Example
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/two-scales.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/two-scales.rs">[code]</a>
     </div>
 </div>
 
@@ -102,7 +102,7 @@
     </a>
     <div class="galleryText">
 		The Matplotlib Matshow Example
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/matshow.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/matshow.rs">[code]</a>
     </div>
 </div>
 
@@ -112,7 +112,7 @@
     </a>
     <div class="galleryText">
 		The Sierpinski Carpet
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/sierpinski.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/sierpinski.rs">[code]</a>
     </div>
 </div>
 
@@ -122,7 +122,7 @@
     </a>
     <div class="galleryText">
 		The 1D Gaussian Distribution
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/nomal-dist2.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/nomal-dist2.rs">[code]</a>
     </div>
 </div>
 
@@ -132,7 +132,7 @@
     </a>
     <div class="galleryText">
 		The 1D Gaussian Distribution
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/errorbar.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/errorbar.rs">[code]</a>
     </div>
 </div>
 
@@ -142,7 +142,7 @@
     </a>
     <div class="galleryText">
 		Monthly Time Coordinate
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/slc-temp.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/slc-temp.rs">[code]</a>
     </div>
 </div>
 
@@ -152,7 +152,7 @@
     </a>
     <div class="galleryText">
 		Monthly Time Coordinate
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/area-chart.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/area-chart.rs">[code]</a>
     </div>
 </div>
 
@@ -162,7 +162,7 @@
     </a>
     <div class="galleryText">
 		Koch Snowflake
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/snowflake.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/snowflake.rs">[code]</a>
     </div>
 </div>
 
@@ -173,7 +173,7 @@
     </a>
     <div class="galleryText">
 		Koch Snowflake Animation
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/animation.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/animation.rs">[code]</a>
     </div>
 </div>
 
@@ -184,7 +184,7 @@
     </a>
     <div class="galleryText">
 		Drawing on a Console
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/console.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs">[code]</a>
     </div>
 </div>
 
@@ -194,7 +194,7 @@
     </a>
     <div class="galleryText">
 		Drawing bitmap on chart
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/blit-bitmap.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/blit-bitmap.rs">[code]</a>
     </div>
 </div>
 
@@ -204,7 +204,7 @@
     </a>
     <div class="galleryText">
 		The boxplot demo
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/boxplot.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/boxplot.rs">[code]</a>
     </div>
 </div>
 
@@ -214,7 +214,7 @@
     </a>
     <div class="galleryText">
 		3D plot rendering
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot.rs">[code]</a>
     </div>
 </div>
 
@@ -224,7 +224,7 @@
     </a>
     <div class="galleryText">
 		2-Var Gussian Distribution PDF
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot2.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot2.rs">[code]</a>
     </div>
 </div>
 
@@ -234,6 +234,6 @@
     </a>
     <div class="galleryText">
 		COVID-19 Visualization
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/tick_control.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/tick_control.rs">[code]</a>
     </div>
 </div>

--- a/doc-template/update_readme.sh
+++ b/doc-template/update_readme.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ev
 REPO_BASE=`readlink -f $(dirname $(readlink -f $0))/../`
 ${REPO_BASE}/doc-template/render_readme.sh ${REPO_BASE}/doc-template/readme.template.md ${REPO_BASE}/doc-template/readme > ${REPO_BASE}/README.md
 

--- a/plotters-backend/README.md
+++ b/plotters-backend/README.md
@@ -3,6 +3,6 @@
 This is a part of plotters project. For more details, please check the following links:
 
 - For high-level intro of Plotters, see: [Plotters on crates.io](https://crates.io/crates/plotters)
-- Check the main repo at [Plotters repo](https://github.com/38/plotters.git)
+- Check the main repo at [Plotters repo](https://github.com/plotters-rs/plotters.git)
 - For detailed documentation about this crate, check [plotters-backend on docs.rs](https://docs.rs/plotters-backend/)
 - You can also visit Plotters [Homepage](https://plotters-rs.github.io)

--- a/plotters-bitmap/README.md
+++ b/plotters-bitmap/README.md
@@ -3,6 +3,6 @@
 This is a part of plotters project. For more details, please check the following links:
 
 - For high-level intro of Plotters, see: [Plotters on crates.io](https://crates.io/crates/plotters)
-- Check the main repo at [Plotters repo](https://github.com/38/plotters.git)
+- Check the main repo at [Plotters repo](https://github.com/plotters-rs/plotters.git)
 - For detailed documentation about this crate, check [plotters-backend on docs.rs](https://docs.rs/plotters-backend/)
 - You can also visit Plotters [Homepage](https://plotters-rs.github.io)

--- a/plotters-svg/README.md
+++ b/plotters-svg/README.md
@@ -3,6 +3,6 @@
 This is a part of plotters project. For more details, please check the following links:
 
 - For high-level intro of Plotters, see: [Plotters on crates.io](https://crates.io/crates/plotters)
-- Check the main repo at [Plotters repo](https://github.com/38/plotters.git)
+- Check the main repo at [Plotters repo](https://github.com/plotters-rs/plotters.git)
 - For detailed documentation about this crate, check [plotters-backend on docs.rs](https://docs.rs/plotters-backend/)
 - You can also visit Plotters [Homepage](https://plotters-rs.github.io)

--- a/plotters/src/chart/dual_coord.rs
+++ b/plotters/src/chart/dual_coord.rs
@@ -20,7 +20,7 @@ use plotters_backend::{BackendCoord, DrawingBackend};
 /// This situation is quite common, for example, we with two different coodinate system.
 /// For instance this example <img src="https://plotters-rs.github.io/plotters-doc-data/twoscale.png"></img>
 /// This is done by attaching  a second coordinate system to ChartContext by method [ChartContext::set_secondary_coord](struct.ChartContext.html#method.set_secondary_coord).
-/// For instance of dual coordinate charts, see [this example](https://github.com/38/plotters/blob/master/examples/two-scales.rs#L15).
+/// For instance of dual coordinate charts, see [this example](https://github.com/plotters-rs/plotters/blob/master/examples/two-scales.rs#L15).
 /// Note: `DualCoordChartContext` is always deref to the chart context.
 /// - If you want to configure the secondary axis, method [DualCoordChartContext::configure_secondary_axes](struct.DualCoordChartContext.html#method.configure_secondary_axes)
 /// - If you want to draw a series using secondary coordinate system, use [DualCoordChartContext::draw_secondary_series](struct.DualCoordChartContext.html#method.draw_secondary_series). And method [ChartContext::draw_series](struct.ChartContext.html#method.draw_series) will always use primary coordinate spec.

--- a/plotters/src/lib.rs
+++ b/plotters/src/lib.rs
@@ -22,7 +22,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
 - A new Plotters Developer's Guide is a work in progress. The preview version is available [here](https://plotters-rs.github.io/book).
 - Try Plotters with an interactive Jupyter notebook, or view [here](https://plotters-rs.github.io/plotters-doc-data/evcxr-jupyter-integration.html) for the static HTML version.
 - To view the WASM example, go to this [link](https://plotters-rs.github.io/wasm-demo/www/index.html)
-- Currently we have all the internal code ready for console plotting, but a console based backend is still not ready. See [this example](https://github.com/38/plotters/blob/master/examples/console.rs) for how to plot on console with a customized backend.
+- Currently we have all the internal code ready for console plotting, but a console based backend is still not ready. See [this example](https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs) for how to plot on console with a customized backend.
 - Plotters has moved all backend code to separate repositories, check [FAQ list](#faq-list) for details
 - Some interesting [demo projects](#demo-projects) are available, feel free to try them out.
 
@@ -34,7 +34,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Multiple Plot
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/chart.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/chart.rs">[code]</a>
     </div>
 </div>
 
@@ -44,7 +44,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Candlestick Plot
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/stock.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/stock.rs">[code]</a>
     </div>
 </div>
 
@@ -54,7 +54,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
        Histogram
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/histogram.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/histogram.rs">[code]</a>
     </div>
 </div>
 
@@ -82,7 +82,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Mandelbrot set
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/mandelbrot.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/mandelbrot.rs">[code]</a>
     </div>
 </div>
 
@@ -112,7 +112,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Histogram with Scatter
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/normal-dist.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/normal-dist.rs">[code]</a>
     </div>
 </div>
 
@@ -122,7 +122,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Dual Y-Axis Example
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/two-scales.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/two-scales.rs">[code]</a>
     </div>
 </div>
 
@@ -132,7 +132,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         The Matplotlib Matshow Example
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/matshow.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/matshow.rs">[code]</a>
     </div>
 </div>
 
@@ -142,7 +142,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         The Sierpinski Carpet
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/sierpinski.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/sierpinski.rs">[code]</a>
     </div>
 </div>
 
@@ -152,7 +152,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         The 1D Gaussian Distribution
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/nomal-dist2.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/nomal-dist2.rs">[code]</a>
     </div>
 </div>
 
@@ -162,7 +162,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         The 1D Gaussian Distribution
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/errorbar.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/errorbar.rs">[code]</a>
     </div>
 </div>
 
@@ -172,7 +172,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Monthly Time Coordinate
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/slc-temp.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/slc-temp.rs">[code]</a>
     </div>
 </div>
 
@@ -182,7 +182,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Monthly Time Coordinate
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/area-chart.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/area-chart.rs">[code]</a>
     </div>
 </div>
 
@@ -192,7 +192,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Koch Snowflake
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/snowflake.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/snowflake.rs">[code]</a>
     </div>
 </div>
 
@@ -203,7 +203,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Koch Snowflake Animation
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/animation.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/animation.rs">[code]</a>
     </div>
 </div>
 
@@ -214,7 +214,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Drawing on a Console
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/console.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/console.rs">[code]</a>
     </div>
 </div>
 
@@ -224,7 +224,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         Drawing bitmap on chart
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/blit-bitmap.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/blit-bitmap.rs">[code]</a>
     </div>
 </div>
 
@@ -234,7 +234,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         The boxplot demo
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/boxplot.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/boxplot.rs">[code]</a>
     </div>
 </div>
 
@@ -244,7 +244,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         3D plot rendering
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot.rs">[code]</a>
     </div>
 </div>
 
@@ -254,7 +254,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         2-Var Gussian Distribution PDF
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/3d-plot2.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/3d-plot2.rs">[code]</a>
     </div>
 </div>
 
@@ -264,7 +264,7 @@ including bitmap, vector graph, piston window, GTK/Cairo and WebAssembly.
     </a>
     <div class="galleryText">
         COVID-19 Visualization
-        <a href="https://github.com/38/plotters/blob/master/plotters/examples/tick_control.rs">[code]</a>
+        <a href="https://github.com/plotters-rs/plotters/blob/master/plotters/examples/tick_control.rs">[code]</a>
     </div>
 </div>
 
@@ -361,7 +361,7 @@ The feature `evcxr` should be enabled when including Plotters to Jupyter Noteboo
 The following code shows a minimal example of this.
 
 ```text
-:dep plotters = { git = "https://github.com/38/plotters", default_features = false, features = ["evcxr"] }
+:dep plotters = { git = "https://github.com/plotters-rs/plotters", default_features = false, features = ["evcxr"] }
 extern crate plotters;
 use plotters::prelude::*;
 
@@ -627,14 +627,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Development Version
 
-Find the latest development version of Plotters on [GitHub](https://github.com/38/plotters.git).
+Find the latest development version of Plotters on [GitHub](https://github.com/plotters-rs/plotters.git).
 Clone the repository and learn more about the Plotters API and ways to contribute. Your help is needed!
 
 If you want to add the development version of Plotters to your project, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-plotters = { git = "https://github.com/38/plotters.git" }
+plotters = { git = "https://github.com/plotters-rs/plotters.git" }
 ```
 
 ### Reducing Depending Libraries && Turning Off Backends
@@ -648,7 +648,7 @@ For example, the following dependency description would avoid compiling with bit
 
 ```toml
 [dependencies]
-plotters = { git = "https://github.com/38/plotters.git", default_features = false, features = ["svg"] }
+plotters = { git = "https://github.com/plotters-rs/plotters.git", default_features = false, features = ["svg"] }
 ```
 
 The library also allows consumers to make use of the [`Palette`](https://crates.io/crates/palette/) crate's color types by default.


### PR DESCRIPTION
The console.rs example link in README.md is broken, because plotter now use cargo workspace.

