### PR TITLE
Fixed cpustat example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To view the source code for each example, please click on the example image.
 </a>
 
 
-<a href="https://github.com/plotters-rs/plotters-piston/blob/master/plotters/examples/cpustat.rs">
+<a href="https://github.com/plotters-rs/plotters-piston/blob/master/examples/cpustat.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/plotters-piston.gif" class="galleryItem" width=200px></img>
 </a>
 

--- a/doc-template/readme/gallery
+++ b/doc-template/readme/gallery
@@ -29,7 +29,7 @@ To view the source code for each example, please click on the example image.
 </a>
 
 
-<a href="https://github.com/plotters-rs/plotters-piston/blob/master/plotters/examples/cpustat.rs">
+<a href="https://github.com/plotters-rs/plotters-piston/blob/master/examples/cpustat.rs">
     <img src="https://plotters-rs.github.io/plotters-doc-data/plotters-piston.gif" class="galleryItem" width=200px></img>
 </a>
 


### PR DESCRIPTION
Updated dead link to correctly point to the [cpustat.rs ](https://github.com/plotters-rs/plotters-piston/blob/master/examples/cpustat.rs) 