### PR TITLE
Make error type 'static.

### DIFF
--- a/plotters-backend/src/lib.rs
+++ b/plotters-backend/src/lib.rs
@@ -105,7 +105,7 @@ impl<E: Error + Send + Sync> Error for DrawingErrorKind<E> {}
 ///  will use the pixel-based approach to draw other types of low-level shapes.
 pub trait DrawingBackend: Sized {
     /// The error type reported by the backend
-    type ErrorType: Error + Send + Sync;
+    type ErrorType: Error + Send + Sync + 'static;
 
     /// Get the dimension of the drawing backend in pixels
     fn get_size(&self) -> (u32, u32);

--- a/plotters/examples/console.rs
+++ b/plotters/examples/console.rs
@@ -151,10 +151,7 @@ impl DrawingBackend for TextDrawingBackend {
 
 fn draw_chart<DB: DrawingBackend>(
     b: DrawingArea<DB, plotters::coord::Shift>,
-) -> Result<(), Box<dyn Error>>
-where
-    DB::ErrorType: 'static,
-{
+) -> Result<(), Box<dyn Error>> {
     let mut chart = ChartBuilder::on(&b)
         .margin(1)
         .caption("Sine and Cosine", ("sans-serif", (10).percent_height()))


### PR DESCRIPTION
This pull request makes the drawing backend error type 'static which makes returning errors more pleasant.
Currently the `draw_chart` function was not callable if this was not the case any ways.

```rust
fn some_func<DB>(
    area: &DrawingArea<DB, plotters::coord::Shift>,
  ) -> Result<(), Box<dyn std::error::Error>>
  where
    DB: DrawingBackend,
    // DB::ErrorType: 'static, not necessary any more, not very intuitive
  {
    let mut chart = ChartBuilder::on(area)
      .margin(10)
      .x_label_area_size(30)
      .y_label_area_size(30)
      .build_cartesian_2d(-1_f64..1_f64, -1_f64..1_f64)?;
    chart.configure_mesh().x_labels(20).y_labels(20).draw()?;
    Ok(())
  }
  ```
