### PR TITLE
fixed readme and docs in lib.rs with correct :dep for jupyter notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The feature `evcxr` should be enabled when including Plotters to Jupyter Noteboo
 The following code shows a minimal example of this.
 
 ```text
-:dep plotters = { git = "https://github.com/plotters-rs/plotters", default_features = false, features = ["evcxr"] }
+:dep plotters = { version = "^0.3.4", default_features = false, features = ["evcxr", "all_series", "all_elements"] }
 extern crate plotters;
 use plotters::prelude::*;
 

--- a/plotters/src/lib.rs
+++ b/plotters/src/lib.rs
@@ -361,7 +361,7 @@ The feature `evcxr` should be enabled when including Plotters to Jupyter Noteboo
 The following code shows a minimal example of this.
 
 ```text
-:dep plotters = { git = "https://github.com/plotters-rs/plotters", default_features = false, features = ["evcxr"] }
+:dep plotters = { version = "^0.3.4", default_features = false, features = ["evcxr", "all_series", "all_elements"] }
 extern crate plotters;
 use plotters::prelude::*;
 


### PR DESCRIPTION
I noticed, the example in the docs and the Readme for Jupyter notebooks did not work. I got the error 

> [E0432] Error: unresolved import `plotters::prelude::LineSeries`

I solved the issue by copying the first line from https://plotters-rs.github.io/plotters-doc-data/evcxr-jupyter-integration.html. This fixed it for me. 

I hope, I was able to help with this pull request.