### PR TITLE
Introduce Colormaps

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -70,7 +70,8 @@ default = [
         "ttf",
         "image",
         "deprecated_items",  "all_series", "all_elements",
-        "full_palette"
+        "full_palette",
+        "colormaps"
 ]
 all_series = ["area_series", "line_series", "point_series", "surface_series"]
 all_elements = ["errorbar", "candlestick", "boxplot", "histogram"]
@@ -83,6 +84,7 @@ svg_backend = ["plotters-svg"]
 
 # Colors
 full_palette = []
+colormaps = []
 
 # Elements
 errorbar = []

--- a/plotters/examples/3d-plot2.rs
+++ b/plotters/examples/3d-plot2.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 pdf,
             )
             .style_func(&|&v| {
-                (&HSLColor(240.0 / 360.0 - 240.0 / 360.0 * v / 5.0, 1.0, 0.7)).into()
+                (VulcanoHSL::get_color(v / 5.0)).into()
             }),
         )?;
 

--- a/plotters/examples/colormaps.rs
+++ b/plotters/examples/colormaps.rs
@@ -1,0 +1,68 @@
+use plotters::prelude::*;
+
+const OUT_FILE_NAME: &'static str = "plotters-doc-data/colormaps.png";
+
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let colormaps_rgb: [(Box<dyn ColorMap<RGBColor>>, &str); 4] = [
+        (Box::new(ViridisRGB {}),"Viridis"),
+        (Box::new(BlackWhite {}),"BlackWhite"),
+        (Box::new(Bone {}),"Bone"),
+        (Box::new(Copper {}),"Copper"),
+    ];
+
+    let colormaps_hsl: [(Box<dyn ColorMap<HSLColor>>, &str); 2] = [
+        (Box::new(MandelbrotHSL {}), "MandelbrotHSL"),
+        (Box::new(VulcanoHSL {}), "VulcanoHSL"),
+    ];
+
+    let size_x: i32 = 800;
+    let n_colormaps = colormaps_rgb.len() + colormaps_hsl.len();
+    let size_y = 200 + n_colormaps as u32 * 100;
+    let root = BitMapBackend::new(OUT_FILE_NAME, (size_x as u32, size_y)).into_drawing_area();
+
+    root.fill(&WHITE)?;
+
+    let mut chart = ChartBuilder::on(&root)
+        .caption("Demonstration of predefined colormaps", ("sans-serif", 20))
+        .build_cartesian_2d(-150.0..size_x as f32+50.0, 0.0..3.0*(n_colormaps as f32))?;
+
+    use plotters::style::text_anchor::*;
+    let centered = Pos::new(HPos::Center, VPos::Center);
+    let label_style = TextStyle::from(("monospace", 14.0).into_font()).pos(centered);
+
+    let mut colormap_counter = 0;
+    macro_rules! plot_colormaps(
+        ($colormap:expr) => {
+            for (colormap, colormap_name) in $colormap.iter() {
+                chart.draw_series(
+                    (0..size_x as i32).map(|x| {
+                        Rectangle::new([
+                            (x as f32,     3.0*(n_colormaps - 1 - colormap_counter) as f32 + 0.5),
+                            (x as f32+1.0, 3.0*(n_colormaps - 1 - colormap_counter) as f32 + 2.5)
+                        ],
+                    colormap.get_color_normalized(x as f32, 0.0, size_x as f32).filled())
+                    })
+                )?;
+                chart.draw_series(
+                    [Text::new(colormap_name.to_owned(), (-75.0, 3.0*(n_colormaps-1-colormap_counter) as f32 + 1.5), &label_style)]
+                )?;
+                colormap_counter+=1;
+            }
+        }
+    );
+
+    plot_colormaps!(colormaps_rgb);
+    plot_colormaps!(colormaps_hsl);
+
+
+    // To avoid the IO failure being ignored silently, we manually call the present function
+    root.present().expect("Unable to write result to file, please make sure 'plotters-doc-data' dir exists under current dir");
+    println!("Result has been saved to {}", OUT_FILE_NAME);
+
+    Ok(())
+}
+#[test]
+fn entry_point() {
+    main().unwrap()
+}

--- a/plotters/examples/mandelbrot.rs
+++ b/plotters/examples/mandelbrot.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for (x, y, c) in mandelbrot_set(xr, yr, (pw as usize, ph as usize), 100) {
         if c != 100 {
-            plotting_area.draw_pixel((x, y), &HSLColor(c as f64 / 100.0, 1.0, 0.5))?;
+            plotting_area.draw_pixel((x, y), &MandelbrotHSL::get_color(c as f64 / 100.0))?;
         } else {
             plotting_area.draw_pixel((x, y), &BLACK)?;
         }

--- a/plotters/src/lib.rs
+++ b/plotters/src/lib.rs
@@ -852,6 +852,9 @@ pub mod prelude {
     #[cfg(feature = "full_palette")]
     pub use crate::style::full_palette;
 
+    #[cfg(feature = "colormaps")]
+    pub use crate::style::colors::colormaps::*;
+
     pub use crate::style::{
         AsRelative, Color, FontDesc, FontFamily, FontStyle, FontTransform, HSLColor, IntoFont,
         IntoTextStyle, Palette, Palette100, Palette99, Palette9999, PaletteColor, RGBAColor,

--- a/plotters/src/style/colors/colormaps.rs
+++ b/plotters/src/style/colors/colormaps.rs
@@ -1,3 +1,7 @@
+use crate::style::{HSLColor,RGBAColor,RGBColor};
+
+use num_traits::{Float,ToPrimitive,FromPrimitive};
+
 pub trait ColorScale<ColorType: crate::prelude::Color, FloatType=f32>
 where
     FloatType: Float,
@@ -7,4 +11,81 @@ where
     }
 
     fn get_color_normalized(&self, h: FloatType, min: FloatType, max: FloatType) -> ColorType;
+}
+
+
+macro_rules! count {
+    () => (0usize);
+    ($x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));
+}
+
+
+macro_rules! define_colors_from_list_of_values_or_directly{
+    ($color_type:tt, $(($($color_value:expr),+)),+) => {
+        [$($color_type($($color_value),+)),+]
+    };
+    ($($color_complete:tt),+) => {
+        [$($color_complete),+]
+    };
+}
+
+
+macro_rules! implement_linear_interpolation_color_map{
+    ($color_scale_name:ident, $color_type:tt) => {
+        impl<FloatType: std::fmt::Debug + Float + FromPrimitive + ToPrimitive> ColorScale<$color_type, FloatType> for $color_scale_name {
+            fn get_color_normalized(&self, h: FloatType, min: FloatType, max: FloatType) -> $color_type {
+                // Ensure that we do have a value in bounds
+                let h = h.max(min).min(max);
+                // Make sure that we really have a minimal value which is smaller than the maximal value
+                assert_eq!(min<max, true);
+                // Next calculate a normalized value between 0.0 and 1.0
+                let t = (h - min)/(max-min);
+                let approximate_index = t * (FloatType::from_usize(Self::COLORS.len()).unwrap() - FloatType::one()).max(FloatType::zero());
+                // Calculate which index are the two most nearest of the supplied value
+                let index_lower = approximate_index.floor().to_usize().unwrap();
+                let index_upper = approximate_index.ceil().to_usize().unwrap();
+                // Calculate the relative difference, ie. is the actual value more towards the color of index_upper or index_lower?
+                let relative_difference = approximate_index.ceil() - approximate_index;
+                // Interpolate the final color linearly
+                calculate_new_color_value!(relative_difference, Self::COLORS, index_upper, index_lower, $color_type)
+            }
+        }
+
+        impl $color_scale_name {
+            pub fn get_color<FloatType: std::fmt::Debug + Float + FromPrimitive + ToPrimitive>(h: FloatType) -> $color_type {
+                let color_scale = $color_scale_name {};
+                color_scale.get_color(h)
+            }
+
+            pub fn get_color_normalized<FloatType: std::fmt::Debug + Float + FromPrimitive + ToPrimitive>(h: FloatType, min: FloatType, max: FloatType) -> $color_type {
+                let color_scale = $color_scale_name {};
+                color_scale.get_color_normalized(h, min, max)
+            }
+        }
+    }
+}
+
+
+#[macro_export]
+macro_rules! define_linear_interpolation_color_map{
+    ($color_scale_name:ident, $color_type:tt, $(($($color_value:expr),+)),*) => {
+        pub struct $color_scale_name {}
+
+        impl $color_scale_name {
+            // const COLORS: [$color_type; $number_colors] = [$($color_type($($color_value),+)),+];
+            // const COLORS: [$color_type; count!($(($($color_value:expr),+))*)] = [$($color_type($($color_value),+)),+];
+            const COLORS: [$color_type; count!($(($($color_value:expr),+))*)] = define_colors_from_list_of_values_or_directly!{$color_type, $(($($color_value),+)),*};
+        }
+
+        implement_linear_interpolation_color_map!{$color_scale_name, $color_type}
+    };
+    ($color_scale_name:ident, $color_type:tt, $($color_complete:tt),+) => {
+        pub struct $color_scale_name {}
+
+        impl $color_scale_name {
+            const COLORS: [$color_type; count!($($color_complete)*)] = define_colors_from_list_of_values_or_directly!{$($color_complete),+};
+        }
+
+        implement_linear_interpolation_color_map!{$color_scale_name, $color_type}
+    }
 }

--- a/plotters/src/style/colors/colormaps.rs
+++ b/plotters/src/style/colors/colormaps.rs
@@ -89,3 +89,74 @@ macro_rules! define_linear_interpolation_color_map{
         implement_linear_interpolation_color_map!{$color_scale_name, $color_type}
     }
 }
+
+
+define_linear_interpolation_color_map!{
+    ViridisRGBA,
+    RGBAColor,
+    ( 68,   1,  84, 1.0),
+    ( 70,  50, 127, 1.0),
+    ( 54,  92, 141, 1.0),
+    ( 39, 127, 143, 1.0),
+    ( 31, 162, 136, 1.0),
+    ( 74, 194, 110, 1.0),
+    (160, 219,  57, 1.0),
+    (254, 232,  37, 1.0)
+}
+
+
+define_linear_interpolation_color_map!{
+    ViridisRGB,
+    RGBColor,
+    ( 68,   1,  84),
+    ( 70,  50, 127),
+    ( 54,  92, 141),
+    ( 39, 127, 143),
+    ( 31, 162, 136),
+    ( 74, 194, 110),
+    (160, 219,  57),
+    (254, 232,  37)
+}
+
+
+define_linear_interpolation_color_map!{
+    BlackWhite,
+    RGBColor,
+    (  0,   0,   0),
+    (255, 255,   255)
+}
+
+
+define_linear_interpolation_color_map!{
+    MandelbrotHSL,
+    HSLColor,
+    (0.0, 1.0, 0.5),
+    (1.0, 1.0, 0.5)
+}
+
+
+define_linear_interpolation_color_map!{
+    VulcanoHSL,
+    HSLColor,
+    (2.0/3.0, 1.0, 0.7),
+    (    0.0, 1.0, 0.7)
+}
+
+
+use super::full_palette::*;
+define_linear_interpolation_color_map!{
+    Bone,
+    RGBColor,
+    BLACK,
+    BLUE,
+    WHITE
+}
+
+
+define_linear_interpolation_color_map!{
+    Copper,
+    RGBColor,
+    BLACK,
+    BROWN,
+    ORANGE
+}

--- a/plotters/src/style/colors/colormaps.rs
+++ b/plotters/src/style/colors/colormaps.rs
@@ -2,7 +2,7 @@ use crate::style::{HSLColor,RGBAColor,RGBColor};
 
 use num_traits::{Float,ToPrimitive,FromPrimitive};
 
-pub trait ColorScale<ColorType: crate::prelude::Color, FloatType=f32>
+pub trait ColorMap<ColorType: crate::prelude::Color, FloatType=f32>
 where
     FloatType: Float,
 {
@@ -32,7 +32,7 @@ macro_rules! define_colors_from_list_of_values_or_directly{
 
 macro_rules! implement_linear_interpolation_color_map{
     ($color_scale_name:ident, $color_type:tt) => {
-        impl<FloatType: std::fmt::Debug + Float + FromPrimitive + ToPrimitive> ColorScale<$color_type, FloatType> for $color_scale_name {
+        impl<FloatType: std::fmt::Debug + Float + FromPrimitive + ToPrimitive> ColorMap<$color_type, FloatType> for $color_scale_name {
             fn get_color_normalized(&self, h: FloatType, min: FloatType, max: FloatType) -> $color_type {
                 // Ensure that we do have a value in bounds
                 let h = h.max(min).min(max);

--- a/plotters/src/style/colors/colormaps.rs
+++ b/plotters/src/style/colors/colormaps.rs
@@ -14,6 +14,96 @@ where
 }
 
 
+/// This struct is used to dynamically construct colormaps by giving it a slice of colors.
+/// It can then be used when being intantiated, but not with associated functions.
+/// ```
+/// use plotters::prelude::{BLACK,BLUE,WHITE,DerivedColorMap,ColorMap};
+/// 
+/// let derived_colormap = DerivedColorMap::new(
+///     &[BLACK,
+///     BLUE,
+///     WHITE]
+/// );
+/// 
+/// assert_eq!(derived_colormap.get_color(0.0), BLACK);
+/// assert_eq!(derived_colormap.get_color(0.5), BLUE);
+/// assert_eq!(derived_colormap.get_color(1.0), WHITE);
+/// ```
+pub struct DerivedColorMap<ColorType> {
+    colors: Vec<ColorType>,
+}
+
+
+impl<ColorType: crate::style::Color + Clone> DerivedColorMap<ColorType> {
+    pub fn new(colors: &[ColorType]) -> Self {
+        DerivedColorMap { colors: colors.iter().map(|color| color.clone()).collect::<Vec<_>>() }
+    }
+}
+
+
+macro_rules! calculate_new_color_value(
+    ($relative_difference:expr, $colors:expr, $index_upper:expr, $index_lower:expr, RGBColor) => {
+        RGBColor(
+            // These equations are a very complicated way of writing a simple linear extrapolation with lots of casting between numerical values
+            // In principle every cast should be safe which is why we choose to unwrap
+            //           (1.0  - r)                   *                                           color_value_1  +                   r *                                           color_value_2
+            ((FloatType::one() - $relative_difference) * FloatType::from_u8($colors[$index_upper].0).unwrap() + $relative_difference * FloatType::from_u8($colors[$index_lower].0).unwrap()).round().to_u8().unwrap(),
+            ((FloatType::one() - $relative_difference) * FloatType::from_u8($colors[$index_upper].1).unwrap() + $relative_difference * FloatType::from_u8($colors[$index_lower].1).unwrap()).round().to_u8().unwrap(),
+            ((FloatType::one() - $relative_difference) * FloatType::from_u8($colors[$index_upper].2).unwrap() + $relative_difference * FloatType::from_u8($colors[$index_lower].2).unwrap()).round().to_u8().unwrap()
+        )
+    };
+    ($relative_difference:expr, $colors:expr, $index_upper:expr, $index_lower:expr, RGBAColor) => {
+        RGBAColor(
+            // These equations are a very complicated way of writing a simple linear extrapolation with lots of casting between numerical values
+            // In principle every cast should be safe which is why we choose to unwrap
+            //           (1.0  - r)                   *                                           color_value_1  +                   r *                                           color_value_2
+            ((FloatType::one() - $relative_difference) * FloatType::from_u8($colors[$index_upper].0).unwrap() + $relative_difference * FloatType::from_u8($colors[$index_lower].0).unwrap()).round().to_u8().unwrap(),
+            ((FloatType::one() - $relative_difference) * FloatType::from_u8($colors[$index_upper].1).unwrap() + $relative_difference * FloatType::from_u8($colors[$index_lower].1).unwrap()).round().to_u8().unwrap(),
+            ((FloatType::one() - $relative_difference) * FloatType::from_u8($colors[$index_upper].2).unwrap() + $relative_difference * FloatType::from_u8($colors[$index_lower].2).unwrap()).round().to_u8().unwrap(),
+            ((FloatType::one() - $relative_difference) * FloatType::from_f64($colors[$index_upper].3).unwrap() + $relative_difference * FloatType::from_f64($colors[$index_lower].3).unwrap()).to_f64().unwrap()
+        )
+    };
+    ($relative_difference:expr, $colors:expr, $index_upper:expr, $index_lower:expr, HSLColor) => {
+        HSLColor(
+            // These equations are a very complicated way of writing a simple linear extrapolation with lots of casting between numerical values
+            // In principle every cast should be safe which is why we choose to unwrap
+            //           (1.0  - r)                   *                                           color_value_1  +                   r *                                           color_value_2
+            ((FloatType::one() - $relative_difference) * FloatType::from_f64($colors[$index_upper].0).unwrap() + $relative_difference * FloatType::from_f64($colors[$index_lower].0).unwrap()).to_f64().unwrap(),
+            ((FloatType::one() - $relative_difference) * FloatType::from_f64($colors[$index_upper].1).unwrap() + $relative_difference * FloatType::from_f64($colors[$index_lower].1).unwrap()).to_f64().unwrap(),
+            ((FloatType::one() - $relative_difference) * FloatType::from_f64($colors[$index_upper].2).unwrap() + $relative_difference * FloatType::from_f64($colors[$index_lower].2).unwrap()).to_f64().unwrap(),
+        )
+    };
+);
+
+
+macro_rules! implement_color_scale_for_derived_ColorMap{
+    ($($color_type:tt),+) => {
+        $(
+            impl<FloatType: Float + FromPrimitive + ToPrimitive> ColorMap<$color_type, FloatType> for DerivedColorMap<$color_type> {
+                fn get_color_normalized(&self, h: FloatType, min: FloatType, max: FloatType) -> $color_type {
+                    // Ensure that we do have a value in bounds
+                    let h = h.max(min).min(max);
+                    // Make sure that we really have a minimal value which is smaller than the maximal value
+                    assert_eq!(min<max, true);
+                    // Next calculate a normalized value between 0.0 and 1.0
+                    let t = (h - min)/(max-min);
+                    let approximate_index = t * (FloatType::from_usize(self.colors.len()).unwrap() - FloatType::one()).max(FloatType::zero());
+                    // Calculate which index are the two most nearest of the supplied value
+                    let index_lower = approximate_index.floor().to_usize().unwrap();
+                    let index_upper = approximate_index.ceil().to_usize().unwrap();
+                    // Calculate the relative difference, ie. is the actual value more towards the color of index_upper or index_lower?
+                    let relative_difference = approximate_index.ceil() - approximate_index;
+                    // Interpolate the final color linearly
+                    calculate_new_color_value!(relative_difference, self.colors, index_upper, index_lower, $color_type)
+                }
+            }
+        )+
+    }
+}
+
+implement_color_scale_for_derived_ColorMap!{RGBAColor, RGBColor, HSLColor}
+
+
 macro_rules! count {
     () => (0usize);
     ($x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));

--- a/plotters/src/style/colors/colormaps.rs
+++ b/plotters/src/style/colors/colormaps.rs
@@ -1,0 +1,10 @@
+pub trait ColorScale<ColorType: crate::prelude::Color, FloatType=f32>
+where
+    FloatType: Float,
+{
+    fn get_color(&self, h: FloatType) -> ColorType {
+        self.get_color_normalized(h, FloatType::zero(), FloatType::one())
+    }
+
+    fn get_color_normalized(&self, h: FloatType, min: FloatType, max: FloatType) -> ColorType;
+}

--- a/plotters/src/style/colors/mod.rs
+++ b/plotters/src/style/colors/mod.rs
@@ -58,3 +58,5 @@ define_color!(TRANSPARENT, 0, 0, 0, 0.0, "Transparent");
 
 #[cfg(feature = "full_palette")]
 pub mod full_palette;
+#[cfg(feature = "colormaps")]
+pub mod colormaps;


### PR DESCRIPTION
This PR aims to add Colormaps to plotters. It is only a first version with almost no documentation.
I am happy to discuss the actual implementations and traits and write some documentation when the design is finalized.
To sum up my efforts:
- Define a trait for a colormap
    - Take a (generic) floating point value (between 0.0 and 1.0) and return a corresponding color
    - Can also be called by normalizing with a provided minimum and maximum value
- Define macros to create a colormap from colorvalues or existing colors by linearly interpolating between the individual colors
    - This trait defines individual structs which names are the names of the colormap (ie. `Viridis {}`)
    - These structs can be called by their implemented trait functionality after they have been instantiated
    - or by associated functions (which currently do not belong to the trait but this could be changed).
- I have added a new feature "colormaps" and added it to the default features to optionally deactivate this functionality.
  This is of course debateable and could also be seen as opt-in rather than opt-out.
- I have modified the examples for 3d-plot2 and mandelbrot to showcase the new colormaps
- In addition I have added a new example showcasing currently existing colormaps
- There are still many opportunities to define new and beautiful colormaps

Feel free to critique me in my approach. It was simply a feature I needed myself while using the library which I would like to see added. Thanks for writing this very nice piece of software!