### PR TITLE
Add HPos and VPos::Default to allow the user to override axes label anchors

### DIFF
--- a/plotters-backend/src/lib.rs
+++ b/plotters-backend/src/lib.rs
@@ -236,12 +236,12 @@ pub trait DrawingBackend: Sized {
         let width = (max_x - min_x) as i32;
         let height = (max_y - min_y) as i32;
         let dx = match style.anchor().h_pos {
-            HPos::Left => 0,
+            HPos::Left | HPos::Default => 0,
             HPos::Right => -width,
             HPos::Center => -width / 2,
         };
         let dy = match style.anchor().v_pos {
-            VPos::Top => 0,
+            VPos::Top | VPos::Default => 0,
             VPos::Center => -height / 2,
             VPos::Bottom => -height,
         };

--- a/plotters-backend/src/text.rs
+++ b/plotters-backend/src/text.rs
@@ -60,10 +60,11 @@ impl<'a> From<&'a str> for FontFamily<'a> {
 /// ```
 pub mod text_anchor {
     /// The horizontal position of the anchor point relative to the text.
-    #[derive(Clone, Copy)]
+    #[derive(Default, Clone, Copy)]
     pub enum HPos {
         /// Default value (Left), except chart axes that might provide a different pos.
         /// Use another variant to override the default positionning
+        #[default]
         Default,
         /// Anchor point is on the left side of the text
         Left,
@@ -74,10 +75,11 @@ pub mod text_anchor {
     }
 
     /// The vertical position of the anchor point relative to the text.
-    #[derive(Clone, Copy)]
+    #[derive(Default, Clone, Copy)]
     pub enum VPos {
         /// Default value (Top), except chart axes that might provide a different pos
         /// Use another variant to override the default positionning
+        #[default]
         Default,
         /// Anchor point is on the top of the text
         Top,
@@ -88,7 +90,7 @@ pub mod text_anchor {
     }
 
     /// The text anchor position.
-    #[derive(Clone, Copy)]
+    #[derive(Default, Clone, Copy)]
     pub struct Pos {
         /// The horizontal position of the anchor point
         pub h_pos: HPos,
@@ -110,22 +112,6 @@ pub mod text_anchor {
         /// ```
         pub fn new(h_pos: HPos, v_pos: VPos) -> Self {
             Pos { h_pos, v_pos }
-        }
-
-        /// Create a default text anchor position (top left).
-        ///
-        /// - **returns** The default text anchor position
-        ///
-        /// ```rust
-        /// use plotters_backend::text_anchor::{Pos, HPos, VPos};
-        ///
-        /// let pos = Pos::default();
-        /// ```
-        pub fn default() -> Self {
-            Pos {
-                h_pos: HPos::Default,
-                v_pos: VPos::Default,
-            }
         }
     }
 }

--- a/plotters-backend/src/text.rs
+++ b/plotters-backend/src/text.rs
@@ -62,6 +62,9 @@ pub mod text_anchor {
     /// The horizontal position of the anchor point relative to the text.
     #[derive(Clone, Copy)]
     pub enum HPos {
+        /// Default value (Left), except chart axes that might provide a different pos.
+        /// Use another variant to override the default positionning
+        Default,
         /// Anchor point is on the left side of the text
         Left,
         /// Anchor point is on the right side of the text
@@ -73,6 +76,9 @@ pub mod text_anchor {
     /// The vertical position of the anchor point relative to the text.
     #[derive(Clone, Copy)]
     pub enum VPos {
+        /// Default value (Top), except chart axes that might provide a different pos
+        /// Use another variant to override the default positionning
+        Default,
         /// Anchor point is on the top of the text
         Top,
         /// Anchor point is in the vertical center of the text
@@ -117,8 +123,8 @@ pub mod text_anchor {
         /// ```
         pub fn default() -> Self {
             Pos {
-                h_pos: HPos::Left,
-                v_pos: VPos::Top,
+                h_pos: HPos::Default,
+                v_pos: VPos::Default,
             }
         }
     }

--- a/plotters-svg/src/svg.rs
+++ b/plotters-svg/src/svg.rs
@@ -395,13 +395,13 @@ impl<'a> DrawingBackend for SVGBackend<'a> {
 
         let (x0, y0) = pos;
         let text_anchor = match style.anchor().h_pos {
-            HPos::Left => "start",
+            HPos::Left | HPos::Default => "start",
             HPos::Right => "end",
             HPos::Center => "middle",
         };
 
         let dy = match style.anchor().v_pos {
-            VPos::Top => "0.76em",
+            VPos::Top | VPos::Default => "0.76em",
             VPos::Center => "0.5ex",
             VPos::Bottom => "-0.5ex",
         };

--- a/plotters/examples/console.rs
+++ b/plotters/examples/console.rs
@@ -132,12 +132,12 @@ impl DrawingBackend for TextDrawingBackend {
         let (width, height) = self.estimate_text_size(text, style)?;
         let (width, height) = (width as i32, height as i32);
         let dx = match style.anchor().h_pos {
-            HPos::Left => 0,
+            HPos::Left | HPos::Default => 0,
             HPos::Right => -width,
             HPos::Center => -width / 2,
         };
         let dy = match style.anchor().v_pos {
-            VPos::Top => 0,
+            VPos::Top | VPos::Default => 0,
             VPos::Center => -height / 2,
             VPos::Bottom => -height,
         };

--- a/plotters/src/chart/context/cartesian2d/draw_impl.rs
+++ b/plotters/src/chart/context/cartesian2d/draw_impl.rs
@@ -250,6 +250,16 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, Cartesia
                 (cx, cy + label_offset)
             };
 
+            let h_pos = if matches!(label_style.pos.h_pos, HPos::Default) {
+                h_pos
+            } else {
+                label_style.pos.h_pos
+            };
+            let v_pos = if matches!(label_style.pos.v_pos, VPos::Default) {
+                v_pos
+            } else {
+                label_style.pos.v_pos
+            };
             let label_style = &label_style.pos(Pos::new(h_pos, v_pos));
             area.draw_text(t, label_style, (text_x, text_y))?;
 


### PR DESCRIPTION
Proposition for #463

Add `HPos::Default` and `VPos::Default` variants, that allows to detect intentional changes to anchors and so prevent using unexpected change of position (The documentation didn't tell us axes overrides positioning values).

I decided to create new variants to address the issue of detecting that the user has changed the anchors of one axis's labels. (because the default Pos are `HPos::Left` and `VPos::Top`)

One other possibility is to change how the position is decided in `draw_impl`, based on the `FontTransform`. This may solve the issue as is but still won't allow customization of the position, and additionally we'd want to change the documentation in order to tell the user that positions are not used for axis labels.