### PR TITLE
Allow custom rotation in degrees, for backends that can support it (e.g. SVG)

### DIFF
--- a/plotters-svg/src/svg.rs
+++ b/plotters-svg/src/svg.rs
@@ -8,12 +8,12 @@ use plotters_backend::{
     FontStyle, FontTransform,
 };
 
+use std::fmt::Write as _;
 use std::fs::File;
 #[allow(unused_imports)]
 use std::io::Cursor;
 use std::io::{BufWriter, Error, Write};
 use std::path::Path;
-use std::fmt::Write as _;
 
 fn make_svg_color(color: BackendColor) -> String {
     let (r, g, b) = color.rgb;
@@ -458,6 +458,9 @@ impl<'a> DrawingBackend for SVGBackend<'a> {
             }
             FontTransform::Rotate270 => {
                 attrs.push(("transform", format!("rotate(270, {}, {})", x0, y0)));
+            }
+            FontTransform::RotateAngle(deg) => {
+                attrs.push(("transform", format!("rotate({deg}, {x0}, {y0})")))
             }
             _ => {}
         }


### PR DESCRIPTION
Addresses (part of) #231 

This PR adds a `Degrees(f32)` variant to `FontTransform`, to allow the use of arbitrary angles in supporting backends.
I implemented this support for SVG, as it's the easiest to get around with.

Backends that do not support arbitrary angles (yet or never) should snap to one of the preset angles by rounding the angle and matching against 90 degrees segments (as done in the `transform` implementation of `FontTransform` in `plotters-backend`

Here's an example of the result using `area-chart` example with `SVGBackend` (also fixed the anchors for better readability using PR 464):
![area-chart](https://user-images.githubusercontent.com/26797476/230563629-7257297a-4540-4ba3-a068-aa7befcbce86.png)
