### PR TITLE
delete whitespace so cargo doc will format comment in list

### DIFF
--- a/plotters/src/drawing/area.rs
+++ b/plotters/src/drawing/area.rs
@@ -113,9 +113,9 @@ impl Rect {
 
 /// The abstraction of a drawing area. Plotters uses drawing area as the fundamental abstraction for the
 /// high level drawing API. The major functionality provided by the drawing area is
-///     1. Layout specification - Split the parent drawing area into sub-drawing-areas
-///     2. Coordinate Translation - Allows guest coordinate system attached and used for drawing.
-///     3. Element based drawing - drawing area provides the environment the element can be drawn onto it.
+/// 1. Layout specification - Split the parent drawing area into sub-drawing-areas
+/// 2. Coordinate Translation - Allows guest coordinate system attached and used for drawing.
+/// 3. Element based drawing - drawing area provides the environment the element can be drawn onto it.
 pub struct DrawingArea<DB: DrawingBackend, CT: CoordTranslate> {
     backend: Rc<RefCell<DB>>,
     rect: Rect,


### PR DESCRIPTION
Make this doc-comment should be rendered as list when processed by `cargo doc`.