### PR TITLE
Chore: "Cargo doc" removed this warning.

### DIFF
--- a/plotters-bitmap/src/bitmap.rs
+++ b/plotters-bitmap/src/bitmap.rs
@@ -91,7 +91,7 @@ impl<'a> BitMapBackend<'a, RGBPixel> {
 
     /// Create a new bitmap backend which only lives in-memory
     ///
-    /// When this is used, the bitmap backend will write to a user provided [u8] array (or Vec<u8>)
+    /// When this is used, the bitmap backend will write to a user provided [u8] array (or `Vec<u8>`)
     /// in RGB pixel format.
     ///
     /// Note: This function provides backward compatibility for those code that assumes Plotters


### PR DESCRIPTION
```
warning: unclosed HTML tag `u8`
  --> plotters-bitmap/src/bitmap.rs:94:95
   |
94 |     /// When this is used, the bitmap backend will write to a user provided [u8] array (or Vec<u8>)
   |                                                                                               ^^^^
   |
   = note: `#[warn(rustdoc::invalid_html_tags)]` on by default
help: try marking as source code
   |
94 |     /// When this is used, the bitmap backend will write to a user provided [u8] array (or `Vec<u8>`)
```