### PR TITLE
Minor: Resolved this warning associated with a "Non-Standard" default

### DIFF
--- a/plotters-backend/src/text.rs
+++ b/plotters-backend/src/text.rs
@@ -60,9 +60,10 @@ impl<'a> From<&'a str> for FontFamily<'a> {
 /// ```
 pub mod text_anchor {
     /// The horizontal position of the anchor point relative to the text.
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Default)]
     pub enum HPos {
         /// Anchor point is on the left side of the text
+        #[default]
         Left,
         /// Anchor point is on the right side of the text
         Right,
@@ -71,9 +72,10 @@ pub mod text_anchor {
     }
 
     /// The vertical position of the anchor point relative to the text.
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Default)]
     pub enum VPos {
         /// Anchor point is on the top of the text
+        #[default]
         Top,
         /// Anchor point is in the vertical center of the text
         Center,
@@ -82,7 +84,7 @@ pub mod text_anchor {
     }
 
     /// The text anchor position.
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Default)]
     pub struct Pos {
         /// The horizontal position of the anchor point
         pub h_pos: HPos,
@@ -106,21 +108,6 @@ pub mod text_anchor {
             Pos { h_pos, v_pos }
         }
 
-        /// Create a default text anchor position (top left).
-        ///
-        /// - **returns** The default text anchor position
-        ///
-        /// ```rust
-        /// use plotters_backend::text_anchor::{Pos, HPos, VPos};
-        ///
-        /// let pos = Pos::default();
-        /// ```
-        pub fn default() -> Self {
-            Pos {
-                h_pos: HPos::Left,
-                v_pos: VPos::Top,
-            }
-        }
     }
 }
 


### PR DESCRIPTION
When I looked at the warning, I noted that everything could be auto derived.

```
warning: method `default` can be confused for the standard trait method `std::default::Default::default`
   --> plotters-backend/src/text.rs:120:9
    |
120 | /         pub fn default() -> Self {
121 | |             Pos {
122 | |                 h_pos: HPos::Left,
123 | |                 v_pos: VPos::Top,
124 | |             }
125 | |         }
    | |_________^
    |
    = help: consider implementing the trait `std::default::Default` or choosing a less ambiguous method name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait
    = note: `#[warn(clippy::should_implement_trait)]` on by default
```