### PR TITLE
BugFix: Error propagation is silenced

### DIFF
--- a/plotters/src/style/font/ttf.rs
+++ b/plotters/src/style/font/ttf.rs
@@ -132,16 +132,13 @@ fn load_font_data(face: FontFamily, style: FontStyle) -> FontResult<FontExt> {
     // Then we need to check if the data cache contains the font data
     let cache = DATA_CACHE.read().unwrap();
     if let Some(data) = cache.get(Borrow::<str>::borrow(&key)) {
-        let font_ext = data.clone().map(|handle| {
+        data.clone().map(|handle| {
             handle
                 .load()
                 .map(FontExt::new)
                 .map_err(|e| FontError::FontLoadError(Arc::new(e)))
-        })?;
+        })??;
 
-        if font_ext.is_err() {
-          return font_ext;
-        }
     }
     drop(cache);
 

--- a/plotters/src/style/font/ttf.rs
+++ b/plotters/src/style/font/ttf.rs
@@ -138,7 +138,6 @@ fn load_font_data(face: FontFamily, style: FontStyle) -> FontResult<FontExt> {
                 .map(FontExt::new)
                 .map_err(|e| FontError::FontLoadError(Arc::new(e)))
         })??;
-
     }
     drop(cache);
 

--- a/plotters/src/style/font/ttf.rs
+++ b/plotters/src/style/font/ttf.rs
@@ -132,12 +132,16 @@ fn load_font_data(face: FontFamily, style: FontStyle) -> FontResult<FontExt> {
     // Then we need to check if the data cache contains the font data
     let cache = DATA_CACHE.read().unwrap();
     if let Some(data) = cache.get(Borrow::<str>::borrow(&key)) {
-        data.clone().map(|handle| {
+        let font_ext = data.clone().map(|handle| {
             handle
                 .load()
                 .map(FontExt::new)
                 .map_err(|e| FontError::FontLoadError(Arc::new(e)))
         })?;
+
+        if font_ext.is_err() {
+          return font_ext;
+        }
     }
     drop(cache);
 


### PR DESCRIPTION
```
warning: unused `Result` that must be used
   --> plotters/src/style/font/ttf.rs:135:9
    |
135 | /         data.clone().map(|handle| {
136 | |             handle
137 | |                 .load()
138 | |                 .map(FontExt::new)
139 | |                 .map_err(|e| FontError::FontLoadError(Arc::new(e)))
140 | |         })?;
    | |___________^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
135 |         let _ = data.clone().map(|handle| {
```

When I remove the ? and look at the type of the droppped variable I see that is it Result<Result<FontExt, FontError>, FontError>

Rust is very unintuative on this matter. The solution is to double unwrap.

There are many ways to do this .. I went with a soltions I think is readable.