### PR TITLE
Update logarithmic.rs

### DIFF
--- a/plotters/src/coord/ranged1d/combinators/logarithmic.rs
+++ b/plotters/src/coord/ranged1d/combinators/logarithmic.rs
@@ -46,11 +46,14 @@ impl_log_scalable!(i, u8);
 impl_log_scalable!(i, u16);
 impl_log_scalable!(i, u32);
 impl_log_scalable!(i, u64);
+impl_log_scalable!(i, usize);
 
 impl_log_scalable!(i, i8);
 impl_log_scalable!(i, i16);
 impl_log_scalable!(i, i32);
 impl_log_scalable!(i, i64);
+impl_log_scalable!(i, i128);
+impl_log_scalable!(i, isize);
 
 impl_log_scalable!(f, f32);
 impl_log_scalable!(f, f64);


### PR DESCRIPTION
Soves #517 

Added implementation of the `LogScalable` trait for primitive types `usize`, `isize` and `i128`.