### PR TITLE
types/datetime: replace deprecated chrono::Date* with NaiveDate

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["doc-template", "plotters-doc-data"]
 
 [dependencies]
 num-traits = "0.2.14"
-chrono = { version = "0.4.19", optional = true }
+chrono = { version = "0.4.31", optional = true }
 
 [dependencies.plotters-backend]
 path = "../plotters-backend"

--- a/plotters/examples/slc-temp.rs
+++ b/plotters/examples/slc-temp.rs
@@ -1,8 +1,15 @@
 use plotters::prelude::*;
 
-use chrono::{TimeZone, Utc};
+use chrono::NaiveDate;
 
 use std::error::Error;
+
+// it's safe to use unwrap because we use known good values in test cases
+macro_rules! create_date {
+    ($year:expr, $month:expr, $day:expr) => {
+        NaiveDate::from_ymd_opt($year, $month, $day).unwrap()
+    };
+}
 
 const OUT_FILE_NAME: &'static str = "plotters-doc-data/slc-temp.png";
 fn main() -> Result<(), Box<dyn Error>> {
@@ -20,11 +27,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .set_label_area_size(LabelAreaPosition::Right, 60)
         .set_label_area_size(LabelAreaPosition::Bottom, 40)
         .build_cartesian_2d(
-            (Utc.ymd(2010, 1, 1)..Utc.ymd(2018, 12, 1)).monthly(),
+            (create_date!(2010, 1, 1)..create_date!(2018, 12, 1)).monthly(),
             14.0..104.0,
         )?
         .set_secondary_coord(
-            (Utc.ymd(2010, 1, 1)..Utc.ymd(2018, 12, 1)).monthly(),
+            (create_date!(2010, 1, 1)..create_date!(2018, 12, 1)).monthly(),
             -10.0..40.0,
         );
 
@@ -42,13 +49,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         .draw()?;
 
     chart.draw_series(LineSeries::new(
-        DATA.iter().map(|(y, m, t)| (Utc.ymd(*y, *m, 1), *t)),
+        DATA.iter().map(|(y, m, t)| (create_date!(*y, *m, 1), *t)),
         &BLUE,
     ))?;
 
     chart.draw_series(
         DATA.iter()
-            .map(|(y, m, t)| Circle::new((Utc.ymd(*y, *m, 1), *t), 3, BLUE.filled())),
+            .map(|(y, m, t)| Circle::new((create_date!(*y, *m, 1), *t), 3, BLUE.filled())),
     )?;
 
     // To avoid the IO failure being ignored silently, we manually call the present function

--- a/plotters/examples/stock.rs
+++ b/plotters/examples/stock.rs
@@ -1,11 +1,9 @@
-use chrono::offset::{Local, TimeZone};
-use chrono::{Date, Duration};
+use chrono::{DateTime, Duration, NaiveDate};
 use plotters::prelude::*;
-fn parse_time(t: &str) -> Date<Local> {
-    Local
-        .datetime_from_str(&format!("{} 0:0", t), "%Y-%m-%d %H:%M")
+fn parse_time(t: &str) -> NaiveDate {
+    DateTime::parse_from_str(&format!("{} 0:0", t), "%Y-%m-%d %H:%M")
         .unwrap()
-        .date()
+        .date_naive()
 }
 const OUT_FILE_NAME: &'static str = "plotters-doc-data/stock.png";
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
The chrono crate deprecated the Date and DateTime APIs in favor of NaiveDate* and also added interfaces like from_ymd_opt() which return Options.

Eventually the deprecated APIs will be removed so this migrates to the new APIs (NaiveDate is already implemented, so we just do the minimal required migration).

Deprecation  started since 0.4.23:
https://docs.rs/chrono/0.4.31/chrono/struct.Date.html

While at it, also bump the chrono dep 0.4.20 -> 0.4.31

Closes: #530