### PR TITLE
Fix dashed line algorithm

### DIFF
--- a/plotters/src/series/line_series.rs
+++ b/plotters/src/series/line_series.rs
@@ -144,8 +144,8 @@ mod test {
             });
 
             m.drop_check(|b| {
-                assert_eq!(b.num_draw_path_call, 9);
-                assert_eq!(b.draw_count, 9);
+                assert_eq!(b.num_draw_path_call, 8);
+                assert_eq!(b.draw_count, 8);
             });
         });
 


### PR DESCRIPTION
#483
I'm sorry, I found some problems using the dashed line algorithm. When the distance between points is greater than the `size` or `spacing` of the dashed line, the algorithm will produce an incorrect continuous straight line.

This new algorithm was tested using two curve coordinate sequences (as shown in the following), **"point distance less than `size`"** and **"point distance greater than `size`,"** the above results were corrected.

In addition, if the `size` equals 0 pixel, it will not be drawn.

**Left:** point distance less than `size` or `spacing`
**Right:** point distance greater than `size` or `spacing`
<div>
<img width="48%" src="https://github.com/plotters-rs/plotters/assets/10264720/7340b6a2-a07b-4449-ab86-995cb5de9a5f">
<img width="48%" src="https://github.com/plotters-rs/plotters/assets/10264720/45417ced-007d-4084-a073-009029b7a963">
</div>