### PR TITLE
Fix overflow in `blit_bitmap`

### DIFF
--- a/plotters-backend/src/lib.rs
+++ b/plotters-backend/src/lib.rs
@@ -308,9 +308,9 @@ pub trait DrawingBackend: Sized {
                     break;
                 }
                 // FIXME: This assume we have RGB image buffer
-                let r = src[(dx + dy * w) as usize * 3];
-                let g = src[(dx + dy * w) as usize * 3 + 1];
-                let b = src[(dx + dy * w) as usize * 3 + 2];
+                let r = src[(dx + dy * iw) as usize * 3];
+                let g = src[(dx + dy * iw) as usize * 3 + 1];
+                let b = src[(dx + dy * iw) as usize * 3 + 2];
                 let color = BackendColor {
                     alpha: 1.0,
                     rgb: (r, g, b),


### PR DESCRIPTION
Hey folks, thanks for building this project 🦀 

I ran into an `index out of bounds` error when playing around with the [blit_bitmap](https://github.com/plotters-rs/plotters/blob/master/plotters/examples/blit-bitmap.rs) example when using the `SvgBackend` instead of the `BitmapBackend`:

1. `blit_bitmap` receives dimensions `iw, ih` as parameters, but also calls `get_size()` to retrieve the size of the `DrawingBackend`
2. It then proceeds to use `w, h` to check whether or not the image is being drawn out of bounds (I think)
3. However, it appears that there was a mixup when implementing the image data access, where `w` was used instead of `iw`

The attached change fixes this, though I'm not entirely sure whether the fix takes everything into account 🤔 