### PR TITLE
docs - annotate objects who depend on features

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -132,3 +132,8 @@ wasm-bindgen-test = "0.3.24"
 name = "benchmark"
 harness = false
 path = "benches/main.rs"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]
+

--- a/plotters/src/coord/ranged1d/types/mod.rs
+++ b/plotters/src/coord/ranged1d/types/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "chrono")]
 mod datetime;
 #[cfg(feature = "chrono")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 pub use datetime::{
     IntoMonthly, IntoYearly, Monthly, RangedDate, RangedDateTime, RangedDuration, Yearly,
 };

--- a/plotters/src/element/mod.rs
+++ b/plotters/src/element/mod.rs
@@ -175,21 +175,25 @@ pub use composable::{ComposedElement, EmptyElement};
 #[cfg(feature = "candlestick")]
 mod candlestick;
 #[cfg(feature = "candlestick")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "candlestick")))]
 pub use candlestick::CandleStick;
 
 #[cfg(feature = "errorbar")]
 mod errorbar;
 #[cfg(feature = "errorbar")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "errorbar")))]
 pub use errorbar::{ErrorBar, ErrorBarOrientH, ErrorBarOrientV};
 
 #[cfg(feature = "boxplot")]
 mod boxplot;
 #[cfg(feature = "boxplot")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "boxplot")))]
 pub use boxplot::Boxplot;
 
 #[cfg(feature = "bitmap_backend")]
 mod image;
 #[cfg(feature = "bitmap_backend")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "bitmap_backend")))]
 pub use self::image::BitMapElement;
 
 mod dynelem;

--- a/plotters/src/evcxr.rs
+++ b/plotters/src/evcxr.rs
@@ -4,6 +4,7 @@ use plotters_backend::DrawingBackend;
 use plotters_svg::SVGBackend;
 
 #[cfg(feature = "evcxr_bitmap")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "evcxr_bitmap")))]
 use plotters_bitmap::BitMapBackend;
 
 /// The wrapper for the generated SVG
@@ -47,6 +48,7 @@ pub fn evcxr_figure<
 
 /// Start drawing an evcxr figure
 #[cfg(feature = "evcxr_bitmap")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "evcxr_bitmap")))]
 pub fn evcxr_bitmap_figure<
     Draw: FnOnce(DrawingArea<BitMapBackend, Shift>) -> Result<(), Box<dyn std::error::Error>>,
 >(

--- a/plotters/src/lib.rs
+++ b/plotters/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 /*!
 
 # Plotters - A Rust drawing library focusing on data plotting for both WASM and native applications 🦀📈🚀
@@ -796,12 +797,14 @@ pub mod style;
 
 /// Evaluation Context for Rust. See [the evcxr crate](https://crates.io/crates/evcxr) for more information.
 #[cfg(feature = "evcxr")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "evcxr")))]
 pub mod evcxr;
 
 #[cfg(test)]
 pub use crate::drawing::{check_color, create_mocked_drawing_area};
 
 #[cfg(feature = "palette_ext")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "palette_ext")))]
 pub use palette;
 
 /// The module imports the most commonly used types and modules in Plotters
@@ -825,6 +828,7 @@ pub mod prelude {
     pub use crate::coord::combinators::LogRange;
 
     #[cfg(feature = "chrono")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
     pub use crate::coord::types::{
         IntoMonthly, IntoYearly, RangedDate, RangedDateTime, RangedDuration,
     };
@@ -836,23 +840,30 @@ pub mod prelude {
 
     // Series helpers
     #[cfg(feature = "area_series")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "area_series")))]
     pub use crate::series::AreaSeries;
     #[cfg(feature = "histogram")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "histogram")))]
     pub use crate::series::Histogram;
     #[cfg(feature = "point_series")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "point_series")))]
     pub use crate::series::PointSeries;
     #[cfg(feature = "surface_series")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "surface_series")))]
     pub use crate::series::SurfaceSeries;
     #[cfg(feature = "line_series")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "line_series")))]
     pub use crate::series::{DashedLineSeries, LineSeries};
 
     // Styles
     pub use crate::style::{BLACK, BLUE, CYAN, GREEN, MAGENTA, RED, TRANSPARENT, WHITE, YELLOW};
 
     #[cfg(feature = "full_palette")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "full_palette")))]
     pub use crate::style::full_palette;
 
     #[cfg(feature = "colormaps")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "colormaps")))]
     pub use crate::style::colors::colormaps::*;
 
     pub use crate::style::{
@@ -868,13 +879,17 @@ pub mod prelude {
     };
 
     #[cfg(feature = "boxplot")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "boxplot")))]
     pub use crate::element::Boxplot;
     #[cfg(feature = "candlestick")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "candlestick")))]
     pub use crate::element::CandleStick;
     #[cfg(feature = "errorbar")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "errorbar")))]
     pub use crate::element::ErrorBar;
 
     #[cfg(feature = "bitmap_backend")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bitmap_backend")))]
     pub use crate::element::BitMapElement;
 
     // Data
@@ -882,6 +897,7 @@ pub mod prelude {
 
     // TODO: This should be deprecated and completely removed
     #[cfg(feature = "deprecated_items")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "deprecated_items")))]
     #[allow(deprecated)]
     pub use crate::element::Path;
 
@@ -893,13 +909,16 @@ pub mod prelude {
         Result<T, crate::drawing::DrawingAreaErrorKind<D::ErrorType>>;
 
     #[cfg(feature = "evcxr")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "evcxr")))]
     pub use crate::evcxr::evcxr_figure;
 
     // Re-export tier 1 backends for backward compatibility
     #[cfg(feature = "bitmap_backend")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bitmap_backend")))]
     pub use plotters_bitmap::BitMapBackend;
 
     #[cfg(feature = "svg_backend")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "svg_backend")))]
     pub use plotters_svg::SVGBackend;
 }
 
@@ -907,11 +926,13 @@ pub mod prelude {
 pub mod backend {
     pub use plotters_backend::DrawingBackend;
     #[cfg(feature = "bitmap_backend")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bitmap_backend")))]
     pub use plotters_bitmap::{
         bitmap_pixel::{BGRXPixel, PixelFormat, RGBPixel},
         BitMapBackend,
     };
     #[cfg(feature = "svg_backend")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "svg_backend")))]
     pub use plotters_svg::SVGBackend;
 }
 

--- a/plotters/src/series/mod.rs
+++ b/plotters/src/series/mod.rs
@@ -22,12 +22,17 @@ mod point_series;
 mod surface;
 
 #[cfg(feature = "area_series")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "area_series")))]
 pub use area_series::AreaSeries;
 #[cfg(feature = "histogram")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "histogram")))]
 pub use histogram::Histogram;
 #[cfg(feature = "line_series")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "line_series")))]
 pub use line_series::{DashedLineSeries, LineSeries};
 #[cfg(feature = "point_series")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "point_series")))]
 pub use point_series::PointSeries;
 #[cfg(feature = "surface_series")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "surface_series")))]
 pub use surface::SurfaceSeries;

--- a/plotters/src/style/colors/mod.rs
+++ b/plotters/src/style/colors/mod.rs
@@ -57,9 +57,11 @@ define_color!(MAGENTA, 255, 0, 255, "Magenta");
 define_color!(TRANSPARENT, 0, 0, 0, 0.0, "Transparent");
 
 #[cfg(feature = "colormaps")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "colormaps")))]
 /// Colormaps can be used to simply go from a scalar value to a color value which will be more/less
 /// intense corresponding to the value of the supplied scalar.
 /// These colormaps can also be defined by the user and be used with lower and upper bounds.
 pub mod colormaps;
 #[cfg(feature = "full_palette")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "full_palette")))]
 pub mod full_palette;

--- a/plotters/src/style/mod.rs
+++ b/plotters/src/style/mod.rs
@@ -15,6 +15,7 @@ pub use color::{Color, HSLColor, PaletteColor, RGBAColor, RGBColor};
 pub use colors::{BLACK, BLUE, CYAN, GREEN, MAGENTA, RED, TRANSPARENT, WHITE, YELLOW};
 
 #[cfg(feature = "full_palette")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "full_palette")))]
 pub use colors::full_palette;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "ab_glyph"))]


### PR DESCRIPTION
This approach was copied from other crates such as `syn` https://github.com/dtolnay/syn/ where the `doc_cfg` flag is enabled by the compiler when generating docs in order to annotate which feature enables which objects or methods.

# Try it out
To try out this change a nightly compiler is required (which is used by docs.rs).
However, unrelated to this problem there is a bug in pathfinder which prohibits building with the newest nightly compiler.
A fix is on the way https://github.com/servo/pathfinder/pull/557.
Thus we use a slightly older version
```
rustup update nightly-2024-02-01
# This command has to be executed in the ./plotters/ subdir
cd ./plotters
cargo +nightly-2024-02-01 rustdoc --all-features -- --cfg doc_cfg
```

Visit `plotters::prelude` to see some of these annotations and compare with https://docs.rs/syn/latest/syn/.