### PR TITLE
Fix [BUG] Rotated labels overlap with the chart #551

### DIFF
--- a/plotters-backend/src/lib.rs
+++ b/plotters-backend/src/lib.rs
@@ -235,12 +235,14 @@ pub trait DrawingBackend: Sized {
         let ((min_x, min_y), (max_x, max_y)) = layout;
         let width = (max_x - min_x) as i32;
         let height = (max_y - min_y) as i32;
-        let dx = match style.anchor().h_pos {
+
+        let anchor = style.anchor().unwrap_or_default();
+        let dx = match anchor.h_pos {
             HPos::Left => 0,
             HPos::Right => -width,
             HPos::Center => -width / 2,
         };
-        let dy = match style.anchor().v_pos {
+        let dy = match anchor.v_pos {
             VPos::Top => 0,
             VPos::Center => -height / 2,
             VPos::Bottom => -height,

--- a/plotters-backend/src/text.rs
+++ b/plotters-backend/src/text.rs
@@ -107,7 +107,6 @@ pub mod text_anchor {
         pub fn new(h_pos: HPos, v_pos: VPos) -> Self {
             Pos { h_pos, v_pos }
         }
-
     }
 }
 
@@ -214,8 +213,8 @@ pub trait BackendTextStyle {
         FontStyle::Normal
     }
 
-    fn anchor(&self) -> text_anchor::Pos {
-        text_anchor::Pos::default()
+    fn anchor(&self) -> Option<text_anchor::Pos> {
+        None
     }
 
     fn family(&self) -> FontFamily;

--- a/plotters-svg/src/svg.rs
+++ b/plotters-svg/src/svg.rs
@@ -394,13 +394,14 @@ impl<'a> DrawingBackend for SVGBackend<'a> {
         }
 
         let (x0, y0) = pos;
-        let text_anchor = match style.anchor().h_pos {
+        let anchor = style.anchor().unwrap_or_default();
+        let text_anchor = match anchor.h_pos {
             HPos::Left => "start",
             HPos::Right => "end",
             HPos::Center => "middle",
         };
 
-        let dy = match style.anchor().v_pos {
+        let dy = match anchor.v_pos {
             VPos::Top => "0.76em",
             VPos::Center => "0.5ex",
             VPos::Bottom => "-0.5ex",
@@ -410,12 +411,12 @@ impl<'a> DrawingBackend for SVGBackend<'a> {
         {
             let ((fx0, fy0), (fx1, fy1)) =
                 font.layout_box(text).map_err(DrawingErrorKind::FontError)?;
-            let x0 = match style.anchor().h_pos {
+            let x0 = match anchor.h_pos {
                 HPos::Left => x0,
                 HPos::Center => x0 - fx1 / 2 + fx0 / 2,
                 HPos::Right => x0 - fx1 + fx0,
             };
-            let y0 = match style.anchor().v_pos {
+            let y0 = match anchor.v_pos {
                 VPos::Top => y0,
                 VPos::Center => y0 - fy1 / 2 + fy0 / 2,
                 VPos::Bottom => y0 - fy1 + fy0,

--- a/plotters/examples/console.rs
+++ b/plotters/examples/console.rs
@@ -131,12 +131,13 @@ impl DrawingBackend for TextDrawingBackend {
     ) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
         let (width, height) = self.estimate_text_size(text, style)?;
         let (width, height) = (width as i32, height as i32);
-        let dx = match style.anchor().h_pos {
+        let style = style.anchor().unwrap_or_default();
+        let dx = match style.h_pos {
             HPos::Left => 0,
             HPos::Right => -width,
             HPos::Center => -width / 2,
         };
-        let dy = match style.anchor().v_pos {
+        let dy = match style.v_pos {
             VPos::Top => 0,
             VPos::Center => -height / 2,
             VPos::Bottom => -height,

--- a/plotters/src/chart/context/cartesian2d/draw_impl.rs
+++ b/plotters/src/chart/context/cartesian2d/draw_impl.rs
@@ -247,8 +247,12 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, Cartesia
                 (cx, cy + label_offset)
             };
 
-            let label_style = &label_style.pos(Pos::new(h_pos, v_pos));
-            area.draw_text(t, label_style, (text_x, text_y))?;
+            let label_style_with_new_pos = label_style.pos(Pos::new(h_pos, v_pos));
+            let label_style = match label_style.anchor() {
+                Some(_) => label_style,
+                None => &label_style_with_new_pos,
+            };
+            area.draw_text(t, &label_style, (text_x, text_y))?;
 
             if tick_size != 0 {
                 if let Some(style) = axis_style {

--- a/plotters/src/chart/context/cartesian2d/draw_impl.rs
+++ b/plotters/src/chart/context/cartesian2d/draw_impl.rs
@@ -248,7 +248,7 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, Cartesia
             };
 
             let label_style_with_new_pos = label_style.pos(Pos::new(h_pos, v_pos));
-            let label_style = match label_style.anchor() {
+            let label_style = match label_style.pos {
                 Some(_) => label_style,
                 None => &label_style_with_new_pos,
             };

--- a/plotters/src/chart/context/cartesian3d/draw_impl.rs
+++ b/plotters/src/chart/context/cartesian3d/draw_impl.rs
@@ -95,16 +95,18 @@ where
             let logic_pos = Coord3D::build_coord([&pos[0], &pos[1], &pos[2]]);
             let mut font = font.clone();
 
-            match dir.0.cmp(&0) {
-                Ordering::Less => font.pos = Pos::new(HPos::Right, VPos::Center),
-                Ordering::Greater => font.pos = Pos::new(HPos::Left, VPos::Center),
-                _ => (),
-            }
+            if font.pos.is_none() {
+                match dir.0.cmp(&0) {
+                    Ordering::Less => font.pos = Some(Pos::new(HPos::Right, VPos::Center)),
+                    Ordering::Greater => font.pos = Some(Pos::new(HPos::Left, VPos::Center)),
+                    _ => (),
+                }
 
-            match dir.1.cmp(&0) {
-                Ordering::Less => font.pos = Pos::new(HPos::Center, VPos::Bottom),
-                Ordering::Greater => font.pos = Pos::new(HPos::Center, VPos::Top),
-                _ => (),
+                match dir.1.cmp(&0) {
+                    Ordering::Less => font.pos = Some(Pos::new(HPos::Center, VPos::Bottom)),
+                    Ordering::Greater => font.pos = Some(Pos::new(HPos::Center, VPos::Top)),
+                    _ => (),
+                }
             }
 
             let element = EmptyElement::at(logic_pos)

--- a/plotters/src/style/font/font_desc.rs
+++ b/plotters/src/style/font/font_desc.rs
@@ -113,7 +113,7 @@ impl<'a> FontDesc<'a> {
         TextStyle {
             font: self.clone(),
             color: color.to_backend_color(),
-            pos: Pos::default(),
+            pos: None,
         }
     }
 

--- a/plotters/src/style/text.rs
+++ b/plotters/src/style/text.rs
@@ -13,7 +13,7 @@ pub struct TextStyle<'a> {
     /// The text color
     pub color: BackendColor,
     /// The anchor point position
-    pub pos: text_anchor::Pos,
+    pub pos: Option<text_anchor::Pos>,
 }
 
 /// Trait for values that can be converted into `TextStyle` values
@@ -191,7 +191,7 @@ impl<'a> TextStyle<'a> {
         Self {
             font: self.font.clone(),
             color: self.color,
-            pos,
+            pos: Some(pos),
         }
     }
 }
@@ -276,7 +276,7 @@ impl<'a, T: Into<FontDesc<'a>>> From<T> for TextStyle<'a> {
         Self {
             font: font.into(),
             color: BLACK.to_backend_color(),
-            pos: text_anchor::Pos::default(),
+            pos: Some(text_anchor::Pos::default()),
         }
     }
 }
@@ -304,7 +304,7 @@ impl<'a> BackendTextStyle for TextStyle<'a> {
         self.font.layout_box(text)
     }
 
-    fn anchor(&self) -> text_anchor::Pos {
+    fn anchor(&self) -> Option<text_anchor::Pos> {
         self.pos
     }
 


### PR DESCRIPTION
Do not override the `label_style.pos` value if it has been defined by the user.

This is the [related discussion](https://github.com/orgs/plotters-rs/discussions/466) for issue #551 . I also commented out a rational for the fix in [here](https://github.com/orgs/plotters-rs/discussions/466#discussioncomment-8589636)

This is a breaking change, but the only breaking change is that the type of `TextStyle.pos` changes from `text_anchor::Pos` to `Option<text_anchor::Pos>`.