### PR TITLE
Add Clone and PartialEq traits to SeriesLabelPosition and ShapeStyle

### DIFF
--- a/plotters/src/chart/series.rs
+++ b/plotters/src/chart/series.rs
@@ -72,6 +72,7 @@ Useful to specify the position of the series label.
 
 See [`ChartContext::configure_series_labels()`] for more information and examples.
 */
+#[derive(Debug, Clone, PartialEq)]
 pub enum SeriesLabelPosition {
     /// Places the series label at the upper left
     UpperLeft,

--- a/plotters/src/style/shape.rs
+++ b/plotters/src/style/shape.rs
@@ -2,7 +2,7 @@ use super::color::{Color, RGBAColor};
 use plotters_backend::{BackendColor, BackendStyle};
 
 /// Style for any shape
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ShapeStyle {
     /// Specification of the color.
     pub color: RGBAColor,


### PR DESCRIPTION
Hello!
Firstly thank you so much for this crate, its very useful and Rust ecosystem really needs such crate!
I have encountered some little roadblocks when using it in our Yew based application and would like to know if it was ok to integrate those changes that seem to benefit to other applications too.

# What

- Add `Debug`, `Clone`, `PartialEq` traits to `SeriesLabelPosition`
- Add `Debug`, `PartialEq` traits to `ShapeStyle`

# Why

Those traits can be quite useful in diverse applications (at least it is when integrating Plotters in WASM Yew based application where the Component Properties must be `PartialEq` and `Clone` ).

# Notes

If there is any other Struct/Enum where we could add those that you think might be relevant too, I could add them in this PR too!


Thank you for your time
