### PR TITLE
Clamp infinite values in logarithmic coordinate system

### DIFF
--- a/plotters/src/chart/builder.rs
+++ b/plotters/src/chart/builder.rs
@@ -565,4 +565,27 @@ mod test {
         chart.caption("This is a test case", ("serif", 10));
         assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "serif");
     }
+
+    #[test]
+    fn test_zero_limit_with_log_scale() {
+        let drawing_area = create_mocked_drawing_area(640, 480, |_| {});
+
+        let mut chart = ChartBuilder::on(&drawing_area)
+            .build_cartesian_2d(0f32..10f32, (1e-6f32..1f32).log_scale())
+            .unwrap();
+
+        let data = vec![
+            (2f32, 1e-4f32),
+            (4f32, 1e-3f32),
+            (6f32, 1e-2f32),
+            (8f32, 1e-1f32),
+        ];
+
+        chart
+            .draw_series(
+                data.iter()
+                    .map(|&(x, y)| Rectangle::new([(x - 0.5, 0.0), (x + 0.5, y)], RED.filled())),
+            )
+            .unwrap();
+    }
 }

--- a/plotters/src/coord/ranged1d/types/numeric.rs
+++ b/plotters/src/coord/ranged1d/types/numeric.rs
@@ -87,6 +87,14 @@ macro_rules! make_numeric_coord {
                     return limit.1;
                 }
 
+                if logic_length.is_infinite() {
+                    if logic_length.is_sign_positive() {
+                        return limit.1;
+                    } else {
+                        return limit.0;
+                    }
+                }
+
                 if actual_length > 0 {
                     return limit.0 + (actual_length as f64 * logic_length + 1e-3).floor() as i32;
                 } else {


### PR DESCRIPTION
Solves https://github.com/plotters-rs/plotters/issues/532

When `LogCoord<V>::map` gets a value equal to zero, [fv.ln()](https://github.com/plotters-rs/plotters/blob/af0b63ca2c0ca18780ec9e92730fa97a444dbfca/plotters/src/coord/ranged1d/combinators/logarithmic.rs#L194) yields -∞.
Map positive and negative infinity to the upper and lower limits to avoid panicking.