### PR TITLE
[FIX] fix datetime addition

### DIFF
--- a/plotters/src/coord/ranged1d/types/datetime.rs
+++ b/plotters/src/coord/ranged1d/types/datetime.rs
@@ -779,7 +779,7 @@ impl Ranged for RangedDuration {
 
                 while current < self.1 {
                     ret.push(current);
-                    current += Duration::nanoseconds(period as i64);
+                    current = current + Duration::nanoseconds(period as i64);
                 }
 
                 return ret;
@@ -818,7 +818,7 @@ impl Ranged for RangedDuration {
 
         while current < self.1 {
             ret.push(current);
-            current += Duration::days(i64::from(days_per_tick));
+            current = current + Duration::days(i64::from(days_per_tick));
         }
 
         ret


### PR DESCRIPTION
The chrono::Duration object doesn't have += operation defined. So instead of using +=, the addition should be done explicitly.
It worked before, but this made it not being compiled, so i fixed it.