### PR TITLE
Clarify Quick Start procedure so program works on first try

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ To use Plotters, you can simply add Plotters into your `Cargo.toml`
 [dependencies]
 plotters = "0.3.3"
 ```
+Create the subdirectory `<Cargo project dir>/plotters-doc-data`
 
-And the following code draws a quadratic function. `src/main.rs`,
+And the following code draws a quadratic function. `src/main.rs` writes the chart to `plotters-doc-data/0.png`
 
 ```rust
 use plotters::prelude::*;


### PR DESCRIPTION
Previously the quadratic function chart Quick Start instructions did not tell the user to create the subdir plotters-doc-data, where the example code writes 0.png.

When the subdir plotters-doc-data does not exist, the code appropriately panics. This does not leave the user with a good first impression of the repository & rust crate.

Now the instructions clearly tell the user to create the subdirectory before running the example program.