### PR TITLE
Relax too strict life times on ChartBuilder

### DIFF
--- a/plotters/src/chart/builder.rs
+++ b/plotters/src/chart/builder.rs
@@ -285,12 +285,12 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
     #[deprecated(
         note = "`build_ranged` has been renamed to `build_cartesian_2d` and is to be removed in the future."
     )]
-    pub fn build_ranged<X: AsRangedCoord, Y: AsRangedCoord>(
+    pub fn build_ranged<'c, X: AsRangedCoord, Y: AsRangedCoord>(
         &mut self,
         x_spec: X,
         y_spec: Y,
     ) -> Result<
-        ChartContext<'a, DB, Cartesian2d<X::CoordDescType, Y::CoordDescType>>,
+        ChartContext<'c, DB, Cartesian2d<X::CoordDescType, Y::CoordDescType>>,
         DrawingAreaErrorKind<DB::ErrorType>,
     > {
         self.build_cartesian_2d(x_spec, y_spec)
@@ -306,12 +306,12 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
     See [`ChartBuilder::on()`] and [`ChartContext::configure_mesh()`] for more information and examples.
     */
     #[allow(clippy::type_complexity)]
-    pub fn build_cartesian_2d<X: AsRangedCoord, Y: AsRangedCoord>(
+    pub fn build_cartesian_2d<'c, X: AsRangedCoord, Y: AsRangedCoord>(
         &mut self,
         x_spec: X,
         y_spec: Y,
     ) -> Result<
-        ChartContext<'a, DB, Cartesian2d<X::CoordDescType, Y::CoordDescType>>,
+        ChartContext<'c, DB, Cartesian2d<X::CoordDescType, Y::CoordDescType>>,
         DrawingAreaErrorKind<DB::ErrorType>,
     > {
         let mut label_areas = [None, None, None, None];
@@ -450,13 +450,13 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
     See [`ChartBuilder::on()`] and [`ChartContext::configure_axes()`] for more information and examples.
     */
     #[allow(clippy::type_complexity)]
-    pub fn build_cartesian_3d<X: AsRangedCoord, Y: AsRangedCoord, Z: AsRangedCoord>(
+    pub fn build_cartesian_3d<'c, X: AsRangedCoord, Y: AsRangedCoord, Z: AsRangedCoord>(
         &mut self,
         x_spec: X,
         y_spec: Y,
         z_spec: Z,
     ) -> Result<
-        ChartContext<'a, DB, Cartesian3d<X::CoordDescType, Y::CoordDescType, Z::CoordDescType>>,
+        ChartContext<'c, DB, Cartesian3d<X::CoordDescType, Y::CoordDescType, Z::CoordDescType>>,
         DrawingAreaErrorKind<DB::ErrorType>,
     > {
         let mut drawing_area = DrawingArea::clone(self.root_area);


### PR DESCRIPTION
The `ChartBuilder`'s lifetimes meant that the `root_area` was not allowed to be dropped after the builder has been finalised (i.e. with a call to `build_cartesian_2d`).  I'm not 100% sure but this feels like unintended behaviour.

Since the `root_area` is cloned and no references to the original (usually `root` DrawingArea) are maintained by the resulting `ChartContext` this lifetime can be relaxed.

This should allow for `ChartContext`s to outlive the `root` drawing areas.

```rust
let drawing_area = create_mocked_drawing_area(640, 480, |_| {});
let mut chart = ChartBuilder::on(&drawing_area)
    .build_cartesian_2d(0f32..10f32, (1e-6f32..1f32).log_scale())
    .unwrap();
drop(drawing_area); // This drop would not be allowed before
// do something with `chart` 
```