### PR TITLE
RangedCoordisize made public

### DIFF
--- a/plotters/src/coord/ranged1d/types/mod.rs
+++ b/plotters/src/coord/ranged1d/types/mod.rs
@@ -9,7 +9,7 @@ pub use datetime::{
 mod numeric;
 pub use numeric::{
     RangedCoordf32, RangedCoordf64, RangedCoordi128, RangedCoordi32, RangedCoordi64,
-    RangedCoordu128, RangedCoordu32, RangedCoordu64, RangedCoordusize,
+    RangedCoordu128, RangedCoordu32, RangedCoordu64, RangedCoordusize, RangedCoordisize,
 };
 
 mod slice;


### PR DESCRIPTION
I think this has just been forgotten. I did not compile this locally only checked for similarities with `RangedCoordusize` and from searching through the repo it seemed like  `RangedCoordisize` was just as "widely" implemented and usable as its `usize`.