### PR TITLE
plotters: update chrono dependency to 0.4.32

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["doc-template", "plotters-doc-data"]
 
 [dependencies]
 num-traits = "0.2.14"
-chrono = { version = "0.4.20", optional = true }
+chrono = { version = "0.4.32", optional = true }
 
 [dependencies.plotters-backend]
 version = "0.3.6"


### PR DESCRIPTION
The plotters code makes use of `AddAssign` on `chrono::Duration` (added in 24bf0638), but that wasn't added to `chrono` until 0.4.32.

Without this fix, if an existing workspace adds `plotters` but already has a `Cargo.lock` containing an earlier release of `chrono` 0.4.x, plotters will fail to compile.

Fixes #624.