### PR TITLE
plotters: Depend on wasm-bindgen 0.2.89 or higher

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -47,10 +47,10 @@ default-features = false
 features = ["jpeg", "png", "bmp"]
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.wasm-bindgen]
-version = "0.2.62"
+version = "0.2.89"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.web-sys]
-version = "0.3.51"
+version = "0.3.66"
 features = [
          "Document",
          "DomRect",
@@ -126,7 +126,7 @@ rand_distr = "0.4.0"
 rand_xorshift = "0.3.0"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
-wasm-bindgen-test = "0.3.24"
+wasm-bindgen-test = "0.3.39"
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
wasm-bindgen 0.2.62 is not compatible with a wasm ABI change that rustc wishes to enable by default for wasm32-unknown-unknown, currently gated behind passing the -Zwasm-c-abi flag to rustc.

wasm-bindgen 0.2.89 should exhibit seamless behavior before and after the ABI change to match the C ABI, so depend on that.

For more information, see
- https://github.com/rust-lang/rust/issues/115666
- https://github.com/rust-lang/rust/pull/117918
- https://github.com/rust-lang/rust/issues/122532