### PR TITLE
Fix backend example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a 800*600 bitmap and start drawing
     let mut backend = BitMapBackend::new("plotters-doc-data/1.png", (300, 200));
     // And if we want SVG backend
-    // let backend = SVGBackend::new("output.svg", (800, 600));
+    // let mut backend = SVGBackend::new("output.svg", (800, 600));
     backend.draw_rect((50, 50), (200, 150), &RED, true)?;
     backend.present()?;
     Ok(())


### PR DESCRIPTION
In the Section "Drawing Backends" under "Concepts by example", the commented line for the SVGBackend is missing a `mut` keyword, this PR resolves this issue.