### PR TITLE
Fix histogram feature grouping on next-release-devel

### DIFF
--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -66,8 +66,8 @@ default = [
         "deprecated_items",  "all_series", "all_elements",
         "full_palette"
 ]
-all_series = ["area_series", "line_series", "point_series", "surface_series"]
-all_elements = ["errorbar", "candlestick", "boxplot", "histogram"]
+all_series = ["area_series", "line_series", "point_series", "surface_series", "histogram"]
+all_elements = ["errorbar", "candlestick", "boxplot"]
 
 # Tier 1 Backends
 bitmap_backend = ["plotters-bitmap", "ttf"]

--- a/plotters/src/element/pie.rs
+++ b/plotters/src/element/pie.rs
@@ -69,7 +69,8 @@ impl<'a, Label: Display> Pie<'a, (i32, i32), Label> {
     /// Default is set to start at 0, which is aligned on the x axis.
     /// ```
     /// use plotters::prelude::*;
-    /// let mut pie = Pie::new(&(50,50), &10.0, &[50.0, 25.25, 20.0, 5.5], &[RED.to_rgba(), BLUE.to_rgba(), GREEN.to_rgba(), WHITE.to_rgba()], &["Red", "Blue", "Green", "White"]);
+    /// let colors = [RED.to_rgba(), BLUE.to_rgba(), GREEN.to_rgba(), WHITE.to_rgba()];
+    /// let mut pie = Pie::new(&(50,50), &10.0, &[50.0, 25.25, 20.0, 5.5], &colors, &["Red", "Blue", "Green", "White"]);
     /// pie.start_angle(-90.0);  // retract to a right angle, so it starts aligned to a vertical Y axis.
     /// ```
     pub fn start_angle(&mut self, start_angle: f64) {


### PR DESCRIPTION
Same goal as before, but since it is an API-breaking change, it is now rebased to `next-release-devel`. Note that I also had to fix a `Pie::new()` doctest that failed to compile.