### PR TITLE
style/color: derive serialize & deserialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,22 @@ pub fn register_font(
 ) -> Result<(), InvalidFont>
 ```
 
+- (De)serialization features
+
+| Name          | Description                              | Additional Dependency | Default? |
+|---------------|------------------------------------------|-----------------------|----------|
+| serialization | Enables serde (de)serialization support  | serde                 | No       |
+
+`serialization` enables support for serializing and deserializing using the serde crate.
+Enable the feature via Cargo.toml then use it like the following:
+```rust,ignore
+#[cfg(feature = "serialization")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+pub struct RGBAColor(pub u8, pub u8, pub u8, pub f64);
+```
+
 - Coordinate features
 
 | Name    |  Description | Additional Dependency |Default?|

--- a/plotters/Cargo.toml
+++ b/plotters/Cargo.toml
@@ -20,6 +20,7 @@ deprecated = { level = "allow" }
 [dependencies]
 num-traits = "0.2.14"
 chrono = { version = "0.4.32", optional = true }
+serde = { version = "1.0.139", optional = true }
 
 [dependencies.plotters-backend]
 version = "0.3.6"
@@ -113,6 +114,7 @@ ab_glyph = ["dep:ab_glyph", "once_cell"]
 
 # Misc
 datetime = ["chrono"]
+serialization = ["serde"]
 evcxr = ["svg_backend"]
 evcxr_bitmap = ["evcxr", "bitmap_backend", "plotters-svg/bitmap_encoder"]
 deprecated_items = [] # Keep some of the deprecated items for backward compatibility
@@ -122,8 +124,8 @@ itertools = "0.10.0"
 criterion = "0.5.1"
 rayon = "1.5.1"
 serde_json = "1.0.82"
-serde = "1.0.139"
 serde_derive = "1.0.140"
+plotters = { path = ".", features = ["serialization"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 rand = "0.8.3"

--- a/plotters/src/style/color.rs
+++ b/plotters/src/style/color.rs
@@ -3,6 +3,9 @@ use super::ShapeStyle;
 
 use plotters_backend::{BackendColor, BackendStyle};
 
+#[cfg(feature = "serialization")]
+use serde::{Deserialize, Serialize};
+
 use std::marker::PhantomData;
 
 /// Any color representation
@@ -64,6 +67,7 @@ impl<T: Color> Color for &'_ T {
 ///
 /// If you want to directly create a RGB color with transparency use [RGBColor::mix]
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct RGBAColor(pub u8, pub u8, pub u8, pub f64);
 
 impl Color for RGBAColor {
@@ -84,6 +88,7 @@ impl From<RGBColor> for RGBAColor {
 
 /// A color in the given palette
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct PaletteColor<P: Palette>(usize, PhantomData<P>);
 
 impl<P: Palette> PaletteColor<P> {
@@ -105,6 +110,7 @@ impl<P: Palette> Color for PaletteColor<P> {
 
 /// The color described by its RGB value
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct RGBColor(pub u8, pub u8, pub u8);
 
 impl BackendStyle for RGBAColor {
@@ -130,6 +136,7 @@ impl BackendStyle for RGBColor {
 
 /// The color described by HSL color space
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct HSLColor(pub f64, pub f64, pub f64);
 
 impl Color for HSLColor {


### PR DESCRIPTION
Using serde is useful in production, not just during development, so move it to optional dependencies instead of dev-dependencies.

This allows to derive serialize/deserialize for the color structs which are very simple using the default implementation, allowing to pass colors along via serialization channels and formats.