### PR TITLE
coord: ranged1d: fix irrefutable if let warning

### DIFF
--- a/plotters/src/coord/ranged1d/types/numeric.rs
+++ b/plotters/src/coord/ranged1d/types/numeric.rs
@@ -26,10 +26,9 @@ macro_rules! impl_discrete_trait {
             }
 
             fn from_index(&self, index: usize) -> Option<Self::ValueType> {
-                if let Ok(index) = Self::ValueType::try_from(index) {
-                    return Some(self.0 + index);
-                }
-                None
+                Self::ValueType::try_from(index)
+                    .ok()
+                    .and_then(|index| self.0.checked_add(index))
             }
         }
     };


### PR DESCRIPTION
I keep getting this annoying warning with rust 1.83:

warning: irrefutable `if let` pattern
   --> plotters/src/coord/ranged1d/types/numeric.rs:29:20
    |
29  |                 if let Ok(index) = Self::ValueType::try_from(index) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
365 | impl_discrete_trait!(RangedCoordusize);
    | -------------------------------------- in this macro invocation
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this warning originates in the macro `impl_discrete_trait` (in Nightly builds, run with -Z macro-backtrace for more info)

This is because the conversion of usize to ValueType always passes, so we don't need the try_from().

The problem with this operation is not the conversion which always succeeds, instead it is the potential overflows, so we use checked_add() which returns None if the addition fails.