### PR TITLE
Refactor FontExt::new to simplify face parsing logic and fix MacOS panic

### DIFF
--- a/plotters/src/style/font/ttf.rs
+++ b/plotters/src/style/font/ttf.rs
@@ -76,14 +76,13 @@ impl Drop for FontExt {
 impl FontExt {
     fn new(font: Font) -> Self {
         let handle = font.handle();
-        let (data, idx) = match handle.as_ref() {
-            Some(Handle::Memory { bytes, font_index }) => (&bytes[..], *font_index),
-            _ => unreachable!(),
-        };
-        let face = unsafe {
-            std::mem::transmute::<Option<_>, Option<Face<'static>>>(
-                ttf_parser::Face::parse(data, idx).ok(),
-            )
+        let face = match handle.as_ref() {
+            Some(Handle::Memory { bytes, font_index }) => unsafe {
+                std::mem::transmute::<Option<_>, Option<Face<'static>>>(
+                    ttf_parser::Face::parse(bytes, *font_index).ok(),
+                )
+            },
+            _ => None,
         };
         Self { inner: font, face }
     }


### PR DESCRIPTION
It used to panic on my MacOS
```log
thread 'main' panicked at /Users/jack/.cargo/git/checkouts/plotters-9c68be5bea4f1f6c/d98282a/plotters/src/style/font/ttf.rs:81:18:
internal error: entered unreachable code
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/panicking.rs:75:14
   2: core::panicking::panic
             at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/panicking.rs:145:5
   3: plotters::style::font::ttf::FontExt::new
             at /Users/jack/.cargo/git/checkouts/plotters-9c68be5bea4f1f6c/d98282a/plotters/src/style/font/ttf.rs:81:18
   4: core::ops::function::FnOnce::call_once
             at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
   5: core::result::Result<T,E>::map
             at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:773:25
   6: plotters::style::font::ttf::load_font_data
             at /Users/jack/.cargo/git/checkouts/plotters-9c68be5bea4f1f6c/d98282a/plotters/src/style/font/ttf.rs:167:20
   7: <plotters::style::font::ttf::FontDataInternal as plotters::style::font::FontData>::new
             at /Users/jack/.cargo/git/checkouts/plotters-9c68be5bea4f1f6c/d98282a/plotters/src/style/font/ttf.rs:204:29
   8: plotters::style::font::font_desc::FontDesc::new
             at /Users/jack/.cargo/git/checkouts/plotters-9c68be5bea4f1f6c/d98282a/plotters/src/style/font/font_desc.rs:36:19
   9: <plotters::style::font::font_desc::FontDesc as core::convert::From<(&str,T)>>::from
             at /Users/jack/.cargo/git/checkouts/plotters-9c68be5bea4f1f6c/d98282a/plotters/src/style/font/font_desc.rs:194:9
  10: <T as core::convert::Into<U>>::into
             at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/convert/mod.rs:761:9
  11: <T as plotters::style::font::font_desc::IntoFont>::into_font
             at /Users/jack/.cargo/git/checkouts/plotters-9c68be5bea4f1f6c/d98282a/plotters/src/style/font/font_desc.rs:218:9
  12: stock::MainViewer::new::{{closure}}
             at ./examples/stock.rs:129:50
  13: <gpui_plot::figure::plotters::PlottersFunc<X,Y,F> as gpui_plot::figure::plotters::GeometryAxesPlotters>::render_axes
             at ./src/figure/plotters.rs:48:9
  14: gpui_plot::figure::plotters::PlottersAxes<X,Y>::plot
             at ./src/figure/plotters.rs:73:9
  15: <gpui_plot::figure::plotters::PlottersAxes<X,Y> as gpui_plot::geometry::GeometryPixels>::render_pixels
             at ./src/figure/plotters.rs:116:27
  16: gpui_plot::figure::plot::PlotContext::render_axes
             at ./src/figure/plot.rs:219:13
  17: <gpui_plot::figure::plot::PlotViewer as gpui::element::Render>::render::{{closure}}
             at ./src/figure/plot.rs:139:25
  18: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  19: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1970:9
  20: <gpui::elements::canvas::Canvas<T> as gpui::element::Element>::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/canvas.rs:79:13
  21: gpui::style::Style::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/style.rs:640:9
  22: <gpui::elements::canvas::Canvas<T> as gpui::element::Element>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/canvas.rs:78:9
  23: gpui::element::Drawable<E>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:383:17
  24: <gpui::element::Drawable<E> as gpui::element::ElementObject>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:470:9
  25: gpui::element::AnyElement::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:527:9
  26: <gpui::elements::div::Div as gpui::element::Element>::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1302:21
  27: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1638:37
  28: gpui::window::Window::with_content_mask
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:1965:13
  29: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1609:29
  30: gpui::window::Window::with_text_style
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:1925:13
  31: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1608:25
  32: gpui::style::Style::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/style.rs:640:9
  33: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1607:21
  34: gpui::window::Window::with_element_opacity
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2007:20
  35: gpui::elements::div::Interactivity::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1606:17
  36: gpui::window::Window::with_optional_element_state
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2237:35
  37: gpui::elements::div::Interactivity::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1584:9
  38: <gpui::elements::div::Div as gpui::element::Element>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1294:9
  39: gpui::element::Drawable<E>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:383:17
  40: <gpui::element::Drawable<E> as gpui::element::ElementObject>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:470:9
  41: gpui::element::AnyElement::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:527:9
  42: gpui::view::<impl gpui::element::Element for gpui::app::entity_map::Entity<V>>::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/view.rs:70:62
  43: gpui::window::Window::with_rendered_view
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2835:22
  44: gpui::view::<impl gpui::element::Element for gpui::app::entity_map::Entity<V>>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/view.rs:70:9
  45: gpui::element::Drawable<E>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:383:17
  46: <gpui::element::Drawable<E> as gpui::element::ElementObject>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:470:9
  47: gpui::element::AnyElement::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:527:9
  48: <gpui::elements::div::Div as gpui::element::Element>::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1302:21
  49: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1638:37
  50: gpui::window::Window::with_content_mask
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:1965:13
  51: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1609:29
  52: gpui::window::Window::with_text_style
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:1921:26
  53: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1608:25
  54: gpui::style::Style::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/style.rs:640:9
  55: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1607:21
  56: gpui::window::Window::with_element_opacity
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2007:20
  57: gpui::elements::div::Interactivity::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1606:17
  58: gpui::window::Window::with_optional_element_state
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2237:35
  59: gpui::elements::div::Interactivity::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1584:9
  60: <gpui::elements::div::Div as gpui::element::Element>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1294:9
  61: gpui::element::Drawable<E>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:383:17
  62: <gpui::element::Drawable<E> as gpui::element::ElementObject>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:470:9
  63: gpui::element::AnyElement::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:527:9
  64: gpui::view::<impl gpui::element::Element for gpui::app::entity_map::Entity<V>>::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/view.rs:70:62
  65: gpui::window::Window::with_rendered_view
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2835:22
  66: gpui::view::<impl gpui::element::Element for gpui::app::entity_map::Entity<V>>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/view.rs:70:9
  67: gpui::element::Drawable<E>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:383:17
  68: <gpui::element::Drawable<E> as gpui::element::ElementObject>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:470:9
  69: gpui::element::AnyElement::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:527:9
  70: <gpui::elements::div::Div as gpui::element::Element>::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1302:21
  71: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1638:37
  72: gpui::window::Window::with_content_mask
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:1965:13
  73: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1609:29
  74: gpui::window::Window::with_text_style
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:1921:26
  75: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1608:25
  76: gpui::style::Style::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/style.rs:640:9
  77: gpui::elements::div::Interactivity::paint::{{closure}}::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1607:21
  78: gpui::window::Window::with_element_opacity
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2007:20
  79: gpui::elements::div::Interactivity::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1606:17
  80: gpui::window::Window::with_optional_element_state
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2237:35
  81: gpui::elements::div::Interactivity::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1584:9
  82: <gpui::elements::div::Div as gpui::element::Element>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/elements/div.rs:1294:9
  83: gpui::element::Drawable<E>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:383:17
  84: <gpui::element::Drawable<E> as gpui::element::ElementObject>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:470:9
  85: gpui::element::AnyElement::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:527:9
  86: <gpui::view::AnyView as gpui::element::Element>::paint::{{closure}}
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/view.rs:273:17
  87: gpui::window::Window::with_rendered_view
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/window.rs:2835:22
  88: <gpui::view::AnyView as gpui::element::Element>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/view.rs:249:9
  89: gpui::element::Drawable<E>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:383:17
  90: <gpui::element::Drawable<E> as gpui::element::ElementObject>::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:470:9
  91: gpui::element::AnyElement::paint
             at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/element.rs:527:9
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

thread 'main' panicked at library/core/src/panicking.rs:218:5:
panic in a function that cannot unwind
stack backtrace:
   0:        0x100f5162c - std::backtrace_rs::backtrace::libunwind::trace::he96961a1cee0c050
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1:        0x100f5162c - std::backtrace_rs::backtrace::trace_unsynchronized::h6700cb7c2f1d79dc
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2:        0x100f5162c - std::sys::backtrace::_print_fmt::h9c654dc4cca7a657
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/sys/backtrace.rs:66:9
   3:        0x100f5162c - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h14ff6fe4beba7dd0
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/sys/backtrace.rs:39:26
   4:        0x100f6e658 - core::fmt::rt::Argument::fmt::h31a27bdc6ccbc7ff
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/fmt/rt.rs:185:76
   5:        0x100f6e658 - core::fmt::write::h7cad866ae568a93f
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/fmt/mod.rs:1449:21
   6:        0x100f4f108 - std::io::Write::write_fmt::h3000a4bd9ea7c5bc
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/io/mod.rs:1890:15
   7:        0x100f514e0 - std::sys::backtrace::BacktraceLock::print::haa70fa42aaec6550
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/sys/backtrace.rs:42:9
   8:        0x100f52380 - std::panicking::default_hook::{{closure}}::h3958857cc06b164d
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:300:22
   9:        0x100f521d0 - std::panicking::default_hook::hd1fb5b886492ddd2
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:327:9
  10:        0x100f52e60 - std::panicking::rust_panic_with_hook::h12dc48bac521315a
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:833:13
  11:        0x100f52a64 - std::panicking::begin_panic_handler::{{closure}}::h142dbc045ec04848
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:699:13
  12:        0x100f51adc - std::sys::backtrace::__rust_end_short_backtrace::h381628983055fbce
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/sys/backtrace.rs:168:18
  13:        0x100f52734 - __rustc[69e8dc581c6f4f16]::rust_begin_unwind
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:697:5
  14:        0x100f9632c - core::panicking::panic_nounwind_fmt::runtime::hbe9a55868bd1f77b
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/panicking.rs:117:22
  15:        0x100f9632c - core::panicking::panic_nounwind_fmt::hc3cc9e587e6fd9d7
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/intrinsics/mod.rs:3240:9
  16:        0x100f963a4 - core::panicking::panic_nounwind::h0de8537cafecc3b5
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/panicking.rs:218:5
  17:        0x100f96504 - core::panicking::panic_cannot_unwind::hc5a9bc54c1bcbdbe
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/panicking.rs:323:5
  18:        0x100a13508 - gpui::platform::mac::window::display_layer::hf99dc60af711b7fd
                               at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/platform/mac/window.rs:1678:1
  19:        0x1a6fe89b0 - <unknown>
  20:        0x1a6fe81b8 - <unknown>
  21:        0x1a71770e4 - <unknown>
  22:        0x1a6fca780 - <unknown>
  23:        0x1a2121a9c - <unknown>
  24:        0x1a2b2c8f4 - <unknown>
  25:        0x19e487be8 - <unknown>
  26:        0x19e487ad4 - <unknown>
  27:        0x19e487104 - <unknown>
  28:        0x19e486734 - <unknown>
  29:        0x1a99f5530 - <unknown>
  30:        0x1a99fb17c - <unknown>
  31:        0x1a99fb508 - <unknown>
  32:        0x1a1ffe848 - <unknown>
  33:        0x1a2964c24 - <unknown>
  34:        0x1a1ff1874 - <unknown>
  35:        0x100e05e7c - <() as objc::message::MessageArguments>::invoke::h0407788938101ff5
                               at /Users/jack/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc-0.2.7/src/message/mod.rs:128:17
  36:        0x100e05128 - objc::message::platform::send_unverified::ha385f6e6b6e24fb4
                               at /Users/jack/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc-0.2.7/src/message/apple/mod.rs:27:9
  37:        0x100df6e50 - objc::message::send_message::h21c03bdf22f9b0f5
                               at /Users/jack/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc-0.2.7/src/message/mod.rs:178:5
  38:        0x100df6e50 - <*mut objc::runtime::Object as cocoa::appkit::NSApplication>::run::h59ec6ecee37a678b
                               at /Users/jack/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cocoa-0.26.0/src/appkit.rs:628:9
  39:        0x1009608b0 - <gpui::platform::mac::platform::MacPlatform as gpui::platform::Platform>::run::hdbf26a0671b746c5
                               at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/platform/mac/platform.rs:440:13
  40:        0x100731358 - gpui::app::Application::run::h51109801df4db593
                               at /Users/jack/.cargo/git/checkouts/zed-a70e2ad075855582/044eb7b/crates/gpui/src/app.rs:164:9
  41:        0x10071cd58 - stock::main::h90087cb40082cd98
                               at /Users/jack/Dev/gpui-plot/examples/stock.rs:190:5
  42:        0x1007178ec - core::ops::function::FnOnce::call_once::hecb1e275813b51d9
                               at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  43:        0x100715bcc - std::sys::backtrace::__rust_begin_short_backtrace::h0ed6aca1ce06f22e
                               at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
  44:        0x100715c54 - std::rt::lang_start::{{closure}}::h2dc5e47a8c898040
                               at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:199:18
  45:        0x100f4a150 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h40e3f1533c603623
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/core/src/ops/function.rs:284:13
  46:        0x100f4a150 - std::panicking::try::do_call::hb8f1bd54552e1b5a
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:589:40
  47:        0x100f4a150 - std::panicking::try::h17c6b3ddcf7963de
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:552:19
  48:        0x100f4a150 - std::panic::catch_unwind::h6181736750f71104
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panic.rs:359:14
  49:        0x100f4a150 - std::rt::lang_start_internal::{{closure}}::hc137e63c283f0b74
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/rt.rs:168:24
  50:        0x100f4a150 - std::panicking::try::do_call::h4bbd58ffef65403e
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:589:40
  51:        0x100f4a150 - std::panicking::try::hce18d57f0d1d72f7
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panicking.rs:552:19
  52:        0x100f4a150 - std::panic::catch_unwind::h67babb78db922b6d
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/panic.rs:359:14
  53:        0x100f4a150 - std::rt::lang_start_internal::h119ecd636fd983e4
                               at /rustc/1aeb99d248e1b0069110cb03c6f1dcc7b36fd7f3/library/std/src/rt.rs:164:5
  54:        0x100715c2c - std::rt::lang_start::h1ae5debd73198da8
                               at /Users/jack/.rustup/toolchains/nightly-2025-03-20-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:198:5
  55:        0x10071cd84 - _main
thread caused non-unwinding panic. aborting.

```


This PR fixes it so it no-longer crash. It might cause the spacing not working though. I couldn't think of how to do that, but it's better than crashing